### PR TITLE
Fetch Keycloak configuration from backend at runtime instead of build…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,7 +19,7 @@ from backend.api.backtest_routes import router as backtest_router
 from backend.api.data_routes import router as data_router
 from backend.api.signal_routes import router as signal_router
 from backend.auth import get_current_user, require_admin
-from backend.config import CORS_ORIGINS
+from backend.config import AUTH_ENABLED, CORS_ORIGINS, KEYCLOAK_FRONTEND_CLIENT_ID, KEYCLOAK_REALM, KEYCLOAK_URL
 from backend.database import get_db, init_db
 from backend.live_tracker import run_live_tracker
 from backend.signal_engine import run_signal_scanner
@@ -66,6 +66,19 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 app.include_router(data_router, prefix="/api", dependencies=[Depends(require_admin)])
 app.include_router(backtest_router, prefix="/api", dependencies=[Depends(get_current_user)])
 app.include_router(signal_router, prefix="/api", dependencies=[Depends(get_current_user)])
+
+
+@app.get("/api/auth/config", tags=["auth"])
+async def auth_config() -> JSONResponse:
+    """Public endpoint returning frontend auth configuration (no auth required)."""
+    return JSONResponse(
+        content={
+            "auth_enabled": AUTH_ENABLED,
+            "keycloak_url": KEYCLOAK_URL,
+            "keycloak_realm": KEYCLOAK_REALM,
+            "keycloak_client_id": KEYCLOAK_FRONTEND_CLIENT_ID,
+        }
+    )
 
 
 @app.get("/healthz", tags=["health"])

--- a/backend/config.py
+++ b/backend/config.py
@@ -24,6 +24,7 @@ AUTH_ENABLED: bool = os.environ.get("AUTH_ENABLED", "false").lower() in ("true",
 KEYCLOAK_URL: str = os.environ.get("KEYCLOAK_URL", "")
 KEYCLOAK_REALM: str = os.environ.get("KEYCLOAK_REALM", "tradingtool-dev")
 KEYCLOAK_AUDIENCE: str = os.environ.get("KEYCLOAK_AUDIENCE", "tradingtool-api")
+KEYCLOAK_FRONTEND_CLIENT_ID: str = os.environ.get("KEYCLOAK_FRONTEND_CLIENT_ID", "tradingtool-web")
 
 # ---------------------------------------------------------------------------
 # App

--- a/frontend/src/auth/AuthProvider.jsx
+++ b/frontend/src/auth/AuthProvider.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts'
-import { AUTH_ENABLED, oidcConfig } from './authConfig'
+import { buildOidcConfig, fetchAuthConfig } from './authConfig'
 import { setAccessToken } from './apiFetch'
 import { AuthContext } from './AuthContext'
 
@@ -27,14 +27,30 @@ function extractRoles(user) {
 }
 
 // ---------------------------------------------------------------------------
-// Provider
+// Top-level provider: fetches runtime config then delegates
 // ---------------------------------------------------------------------------
 
 export function AuthProvider({ children }) {
-  if (!AUTH_ENABLED) {
+  const [cfg, setCfg] = useState(null) // null = still loading
+
+  useEffect(() => {
+    fetchAuthConfig().then(setCfg)
+  }, [])
+
+  if (cfg === null) {
+    // Loading runtime config — render nothing (App shows its own spinner)
+    return (
+      <AuthContext.Provider value={{ isLoading: true, isAuthenticated: false, roles: [], isAdmin: false, login: () => {}, logout: () => {} }}>
+        {children}
+      </AuthContext.Provider>
+    )
+  }
+
+  if (!cfg.auth_enabled) {
     return <MockAuthProvider>{children}</MockAuthProvider>
   }
-  return <KeycloakAuthProvider>{children}</KeycloakAuthProvider>
+
+  return <KeycloakAuthProvider oidcConfig={buildOidcConfig(cfg)}>{children}</KeycloakAuthProvider>
 }
 
 // ---------------------------------------------------------------------------
@@ -42,7 +58,6 @@ export function AuthProvider({ children }) {
 // ---------------------------------------------------------------------------
 
 function MockAuthProvider({ children }) {
-  // Keep token ref in sync so apiFetch works even in mock mode
   useEffect(() => {
     setAccessToken('mock-dev-token')
     return () => setAccessToken(null)
@@ -68,12 +83,11 @@ function MockAuthProvider({ children }) {
 // Real Keycloak provider
 // ---------------------------------------------------------------------------
 
-function KeycloakAuthProvider({ children }) {
+function KeycloakAuthProvider({ oidcConfig, children }) {
   const [user, setUser] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const mgr = useRef(null)
 
-  // Initialise UserManager once
   useEffect(() => {
     const userManager = new UserManager({
       ...oidcConfig,
@@ -81,7 +95,6 @@ function KeycloakAuthProvider({ children }) {
     })
     mgr.current = userManager
 
-    // Keep access token synced
     const onUserLoaded = (u) => {
       setUser(u)
       setAccessToken(u?.access_token ?? null)
@@ -94,18 +107,14 @@ function KeycloakAuthProvider({ children }) {
     userManager.events.addUserLoaded(onUserLoaded)
     userManager.events.addUserUnloaded(onUserUnloaded)
 
-    // Attempt to complete a redirect callback, or load existing session
     const init = async () => {
       try {
-        // If the URL has ?code= we are returning from Keycloak
         if (window.location.search.includes('code=')) {
           const u = await userManager.signinRedirectCallback()
-          // Clean URL
           window.history.replaceState({}, document.title, window.location.pathname)
           setUser(u)
           setAccessToken(u?.access_token ?? null)
         } else {
-          // Try to get existing session
           const u = await userManager.getUser()
           if (u && !u.expired) {
             setUser(u)
@@ -125,7 +134,7 @@ function KeycloakAuthProvider({ children }) {
       userManager.events.removeUserLoaded(onUserLoaded)
       userManager.events.removeUserUnloaded(onUserUnloaded)
     }
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const login = useCallback(() => {
     mgr.current?.signinRedirect()

--- a/frontend/src/auth/authConfig.js
+++ b/frontend/src/auth/authConfig.js
@@ -1,31 +1,46 @@
 /**
- * OIDC / Keycloak configuration built from Vite environment variables.
+ * Auth configuration fetched at runtime from the backend.
  *
- * Env vars (set in .env.development.local or build-time):
- *   VITE_AUTH_ENABLED      – "true" to enable Keycloak login (default: "false")
- *   VITE_KEYCLOAK_URL      – Keycloak base URL
- *   VITE_KEYCLOAK_REALM    – Keycloak realm name (default: "tradingtool-dev")
- *   VITE_KEYCLOAK_CLIENT_ID – OIDC client ID (default: "tradingtool-web")
+ * The backend exposes GET /api/auth/config (no auth required) which returns
+ * the values of AUTH_ENABLED, KEYCLOAK_URL, KEYCLOAK_REALM and
+ * KEYCLOAK_FRONTEND_CLIENT_ID from its environment.
+ *
+ * VITE_* env vars are only used as fallbacks for local `npm run dev` without
+ * a running backend.
  */
 
-export const AUTH_ENABLED =
-  (import.meta.env.VITE_AUTH_ENABLED ?? 'false').toLowerCase() === 'true'
+/**
+ * Fetch auth config from the backend.
+ * Returns a plain object: { auth_enabled, keycloak_url, keycloak_realm, keycloak_client_id }
+ */
+export async function fetchAuthConfig() {
+  try {
+    const res = await fetch('/api/auth/config')
+    if (res.ok) {
+      return await res.json()
+    }
+  } catch {
+    // backend unreachable — fall through to VITE_ defaults (local dev)
+  }
 
-const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL ?? ''
-const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM ?? 'tradingtool-dev'
-const KEYCLOAK_CLIENT_ID =
-  import.meta.env.VITE_KEYCLOAK_CLIENT_ID ?? 'tradingtool-web'
+  return {
+    auth_enabled: (import.meta.env.VITE_AUTH_ENABLED ?? 'false').toLowerCase() === 'true',
+    keycloak_url: import.meta.env.VITE_KEYCLOAK_URL ?? '',
+    keycloak_realm: import.meta.env.VITE_KEYCLOAK_REALM ?? 'tradingtool-dev',
+    keycloak_client_id: import.meta.env.VITE_KEYCLOAK_CLIENT_ID ?? 'tradingtool-web',
+  }
+}
 
-const authority = `${KEYCLOAK_URL}/realms/${KEYCLOAK_REALM}`
-
-/** Settings object for oidc-client-ts UserManager */
-export const oidcConfig = {
-  authority,
-  client_id: KEYCLOAK_CLIENT_ID,
-  redirect_uri: `${window.location.origin}/`,
-  post_logout_redirect_uri: `${window.location.origin}/`,
-  response_type: 'code',
-  scope: 'openid profile email',
-  automaticSilentRenew: true,
-  // PKCE S256 is the default in oidc-client-ts for response_type=code
+/** Build an oidc-client-ts config object from a fetched auth config. */
+export function buildOidcConfig({ keycloak_url, keycloak_realm, keycloak_client_id }) {
+  const authority = `${keycloak_url}/realms/${keycloak_realm}`
+  return {
+    authority,
+    client_id: keycloak_client_id,
+    redirect_uri: `${window.location.origin}/`,
+    post_logout_redirect_uri: `${window.location.origin}/`,
+    response_type: 'code',
+    scope: 'openid profile email',
+    automaticSilentRenew: true,
+  }
 }

--- a/helm/env/dev.yaml
+++ b/helm/env/dev.yaml
@@ -9,6 +9,7 @@ config:
   KEYCLOAK_URL: "https://keycloak-dev.liontechsolution.com"
   KEYCLOAK_REALM: "tradingtool-dev"
   KEYCLOAK_AUDIENCE: "tradingtool-api"
+  KEYCLOAK_FRONTEND_CLIENT_ID: "tradingtool-web"
   CORS_ORIGINS: "*"
 existingSecret: "tradingtools-secret-dev"
 cloudflareTunnel:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -28,6 +28,7 @@ config:
   KEYCLOAK_URL: ""
   KEYCLOAK_REALM: "tradingtool-dev"
   KEYCLOAK_AUDIENCE: "tradingtool-api"
+  KEYCLOAK_FRONTEND_CLIENT_ID: "tradingtool-web"
   CORS_ORIGINS: "*"
 
 resources:


### PR DESCRIPTION
…-time environment variables

- Add /api/auth/config public endpoint to expose auth settings to frontend
- Add KEYCLOAK_FRONTEND_CLIENT_ID config variable to backend and Helm charts
- Replace static VITE_* environment variables with runtime fetch in AuthProvider
- Use VITE_* vars only as fallback for local development without backend
- Update AuthProvider to load config before initializing authentication