### PR TITLE
Add KEYCLOAK_AUDIENCE config variable and handle race condition in us…

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -19,7 +19,14 @@ from backend.api.backtest_routes import router as backtest_router
 from backend.api.data_routes import router as data_router
 from backend.api.signal_routes import router as signal_router
 from backend.auth import get_current_user, require_admin
-from backend.config import AUTH_ENABLED, CORS_ORIGINS, KEYCLOAK_FRONTEND_CLIENT_ID, KEYCLOAK_REALM, KEYCLOAK_URL
+from backend.config import (
+    AUTH_ENABLED,
+    CORS_ORIGINS,
+    KEYCLOAK_AUDIENCE,
+    KEYCLOAK_FRONTEND_CLIENT_ID,
+    KEYCLOAK_REALM,
+    KEYCLOAK_URL,
+)
 from backend.database import get_db, init_db
 from backend.live_tracker import run_live_tracker
 from backend.signal_engine import run_signal_scanner
@@ -77,6 +84,7 @@ async def auth_config() -> JSONResponse:
             "keycloak_url": KEYCLOAK_URL,
             "keycloak_realm": KEYCLOAK_REALM,
             "keycloak_client_id": KEYCLOAK_FRONTEND_CLIENT_ID,
+            "keycloak_audience": KEYCLOAK_AUDIENCE,
         }
     )
 

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -165,14 +165,24 @@ async def _ensure_user(
                 roles=roles,
             )
 
-        # First login — create user
-        cursor = await db.execute(
-            """INSERT INTO users (keycloak_sub, email, username, roles, created_at, last_login_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (keycloak_sub, email, username, roles_json, now, now),
-        )
-        await db.commit()
-        new_id = cursor.lastrowid
+        # First login — create user (race-safe: another request may INSERT first)
+        try:
+            cursor = await db.execute(
+                """INSERT INTO users (keycloak_sub, email, username, roles, created_at, last_login_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (keycloak_sub, email, username, roles_json, now, now),
+            )
+            await db.commit()
+            new_id = cursor.lastrowid
+        except Exception:
+            # UNIQUE constraint violation — concurrent request already inserted
+            await db.commit()
+            cursor = await db.execute(
+                "SELECT id FROM users WHERE keycloak_sub = ?",
+                (keycloak_sub,),
+            )
+            row = await cursor.fetchone()
+            new_id = row[0] if isinstance(row, (list, tuple)) else row["id"]
 
     return AuthUser(
         id=new_id,

--- a/frontend/src/auth/AuthProvider.jsx
+++ b/frontend/src/auth/AuthProvider.jsx
@@ -18,9 +18,13 @@ const MOCK_USER = {
   },
 }
 
-function extractRoles(user) {
+function extractRoles(user, audience = 'tradingtool-api') {
   try {
-    return user?.profile?.resource_access?.['tradingtool-api']?.roles ?? []
+    // Check client roles under resource_access first
+    const clientRoles = user?.profile?.resource_access?.[audience]?.roles ?? []
+    if (clientRoles.length > 0) return clientRoles
+    // Fallback to realm roles
+    return user?.profile?.realm_access?.roles ?? []
   } catch {
     return []
   }
@@ -50,7 +54,7 @@ export function AuthProvider({ children }) {
     return <MockAuthProvider>{children}</MockAuthProvider>
   }
 
-  return <KeycloakAuthProvider oidcConfig={buildOidcConfig(cfg)}>{children}</KeycloakAuthProvider>
+  return <KeycloakAuthProvider oidcConfig={buildOidcConfig(cfg)} audience={cfg.keycloak_audience}>{children}</KeycloakAuthProvider>
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +87,7 @@ function MockAuthProvider({ children }) {
 // Real Keycloak provider
 // ---------------------------------------------------------------------------
 
-function KeycloakAuthProvider({ oidcConfig, children }) {
+function KeycloakAuthProvider({ oidcConfig, audience, children }) {
   const [user, setUser] = useState(null)
   const [isLoading, setIsLoading] = useState(true)
   const mgr = useRef(null)
@@ -144,7 +148,7 @@ function KeycloakAuthProvider({ oidcConfig, children }) {
     mgr.current?.signoutRedirect()
   }, [])
 
-  const roles = extractRoles(user)
+  const roles = extractRoles(user, audience)
 
   const value = {
     user,


### PR DESCRIPTION
…er creation

- Add KEYCLOAK_AUDIENCE to backend config and expose in /api/auth/config endpoint
- Update frontend AuthProvider to accept audience parameter and check client roles before realm roles
- Add race-safe user creation in auth.py to handle concurrent INSERT attempts with UNIQUE constraint violation
- Pass audience to extractRoles function to support configurable client role lookup