### PR TITLE
Add admin-only authorization to data download and metrics endpoints

### DIFF
--- a/backend/api/data_routes.py
+++ b/backend/api/data_routes.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from backend.auth import require_admin
 from backend.binance_client import binance_client
 from backend.database import get_db
 from backend.download_engine import (
@@ -63,7 +64,7 @@ async def list_pairs() -> dict:
     return {"pairs": merged}
 
 
-@router.post("/download")
+@router.post("/download", dependencies=[Depends(require_admin)])
 async def start_download(req: DownloadRequest) -> dict:
     """Start a download job and return its ID."""
     if req.interval not in VALID_INTERVALS:
@@ -87,7 +88,7 @@ async def get_download_status(job_id: int) -> dict:
     return result
 
 
-@router.get("/download/{job_id}/cancel")
+@router.get("/download/{job_id}/cancel", dependencies=[Depends(require_admin)])
 async def cancel_download(job_id: int) -> dict:
     """Cancel a running or pending download job."""
     ok = await cancel_job(job_id)
@@ -129,7 +130,7 @@ async def get_rate_limit() -> dict:
     return binance_client.rate_limit.to_dict()
 
 
-@router.post("/metrics/compute")
+@router.post("/metrics/compute", dependencies=[Depends(require_admin)])
 async def compute_metrics_endpoint(req: MetricsRequest) -> dict:
     """Trigger derived metrics calculation for a symbol/interval."""
     result = await compute_and_store_metrics(

--- a/backend/app.py
+++ b/backend/app.py
@@ -18,7 +18,7 @@ from starlette.responses import Response
 from backend.api.backtest_routes import router as backtest_router
 from backend.api.data_routes import router as data_router
 from backend.api.signal_routes import router as signal_router
-from backend.auth import get_current_user, require_admin
+from backend.auth import get_current_user
 from backend.config import (
     AUTH_ENABLED,
     CORS_ORIGINS,
@@ -70,7 +70,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return JSONResponse(status_code=422, content={"detail": exc.errors(), "body": body.decode()})
 
 
-app.include_router(data_router, prefix="/api", dependencies=[Depends(require_admin)])
+app.include_router(data_router, prefix="/api", dependencies=[Depends(get_current_user)])
 app.include_router(backtest_router, prefix="/api", dependencies=[Depends(get_current_user)])
 app.include_router(signal_router, prefix="/api", dependencies=[Depends(get_current_user)])
 


### PR DESCRIPTION
- Add require_admin dependency to /api/download, /api/download/{job_id}/cancel, and /api/metrics/compute endpoints
- Change data_router global dependency from require_admin to get_current_user to allow authenticated users to access read-only endpoints
- Restrict write operations (download, cancel, compute metrics) to admin users only