### PR TITLE
Add automatic Alembic migration on startup for PostgreSQL and strip q…

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -17,13 +17,14 @@ if config.config_file_name is not None:
 
 target_metadata = None
 
-DATABASE_URL = os.environ.get("DATABASE_URL", "")
+DATABASE_URL = os.environ.get("DATABASE_URL", "").strip().strip("'\"")
 if DATABASE_URL.startswith("postgresql://"):
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 elif DATABASE_URL.startswith("postgres://"):
     DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql+asyncpg://", 1)
 
-config.set_main_option("sqlalchemy.url", DATABASE_URL)
+# Escape % for configparser interpolation
+config.set_main_option("sqlalchemy.url", DATABASE_URL.replace("%", "%%"))
 
 
 def run_migrations_offline() -> None:

--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,7 @@ from backend.auth import get_current_user
 from backend.config import (
     AUTH_ENABLED,
     CORS_ORIGINS,
+    IS_POSTGRES,
     KEYCLOAK_AUDIENCE,
     KEYCLOAK_FRONTEND_CLIENT_ID,
     KEYCLOAK_REALM,
@@ -36,6 +37,7 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    logger.info("Database backend: %s", "PostgreSQL" if IS_POSTGRES else "SQLite (ephemeral)")
     await init_db()
     scanner_task = asyncio.create_task(run_signal_scanner())
     tracker_task = asyncio.create_task(run_live_tracker())

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,7 +9,8 @@ from pathlib import Path
 # Database
 # ---------------------------------------------------------------------------
 
-DATABASE_URL: str | None = os.environ.get("DATABASE_URL")
+_raw_db_url: str | None = os.environ.get("DATABASE_URL")
+DATABASE_URL: str | None = _raw_db_url.strip().strip("'\"") if _raw_db_url else None
 
 IS_POSTGRES: bool = bool(DATABASE_URL and DATABASE_URL.startswith("postgresql"))
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -10,6 +10,7 @@ SQLite init_db() creates the schema on first run; PostgreSQL relies on Alembic m
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -174,13 +175,28 @@ async def get_db():
             yield db
 
 
-async def init_db() -> None:
-    """Create all tables for SQLite local development.
+def _run_alembic_upgrade() -> None:
+    """Run ``alembic upgrade head`` programmatically (synchronous)."""
+    from alembic.config import Config  # noqa: PLC0415
 
-    For PostgreSQL the schema is managed by Alembic migrations — this function
-    is a no-op when DATABASE_URL points to PostgreSQL.
+    from alembic import command  # noqa: PLC0415
+
+    log = logging.getLogger(__name__)
+    log.info("Running Alembic migrations (upgrade head) ...")
+    cfg = Config("alembic.ini")
+    command.upgrade(cfg, "head")
+    log.info("Alembic migrations complete.")
+
+
+async def init_db() -> None:
+    """Initialise the database.
+
+    - **PostgreSQL**: runs Alembic ``upgrade head`` so migrations are applied
+      automatically on every deployment.
+    - **SQLite**: creates all tables inline (no Alembic).
     """
     if IS_POSTGRES:
+        _run_alembic_upgrade()
         return
 
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
…uotes from DATABASE_URL

- Strip leading/trailing whitespace and quotes from DATABASE_URL in config.py and alembic/env.py
- Escape % characters in DATABASE_URL for configparser interpolation in Alembic
- Add _run_alembic_upgrade helper to run Alembic migrations programmatically
- Update init_db to automatically run Alembic upgrade head for PostgreSQL on startup
- Add database backend logging to app lifespan (PostgreSQL vs SQLite)