### PR TITLE
Upgrade GitHub Actions to latest versions and run Alembic migrations …

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -23,10 +23,10 @@ jobs:
       short_sha: ${{ steps.sha.outputs.short }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,13 +37,13 @@ jobs:
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: production
@@ -71,12 +71,12 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.TT_APP_ID }}
           private-key: ${{ secrets.TT_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: develop
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     name: Lint backend (ruff)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -32,9 +32,9 @@ jobs:
     name: Lint frontend (ESLint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -52,9 +52,9 @@ jobs:
     name: Test backend (pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -68,9 +68,9 @@ jobs:
     name: Build frontend (Vite)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/backend/database.py
+++ b/backend/database.py
@@ -175,17 +175,14 @@ async def get_db():
             yield db
 
 
-def _run_alembic_upgrade() -> None:
-    """Run ``alembic upgrade head`` programmatically (synchronous)."""
+def _run_alembic_upgrade_sync() -> None:
+    """Run ``alembic upgrade head`` in a **fresh** event loop (must be called outside asyncio)."""
     from alembic.config import Config  # noqa: PLC0415
 
     from alembic import command  # noqa: PLC0415
 
-    log = logging.getLogger(__name__)
-    log.info("Running Alembic migrations (upgrade head) ...")
     cfg = Config("alembic.ini")
     command.upgrade(cfg, "head")
-    log.info("Alembic migrations complete.")
 
 
 async def init_db() -> None:
@@ -196,7 +193,12 @@ async def init_db() -> None:
     - **SQLite**: creates all tables inline (no Alembic).
     """
     if IS_POSTGRES:
-        _run_alembic_upgrade()
+        import asyncio  # noqa: PLC0415
+
+        log = logging.getLogger(__name__)
+        log.info("Running Alembic migrations (upgrade head) ...")
+        await asyncio.to_thread(_run_alembic_upgrade_sync)
+        log.info("Alembic migrations complete.")
         return
 
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
…asynchronously

- Upgrade actions/checkout from v4 to v6
- Upgrade actions/setup-python from v5 to v6
- Upgrade actions/setup-node from v4 to v6
- Upgrade docker/login-action from v3 to v4
- Upgrade docker/setup-qemu-action from v3 to v4
- Upgrade docker/setup-buildx-action from v3 to v4
- Upgrade docker/build-push-action from v6 to v7
- Upgrade actions/create-github-app-token from v1 to v2
- Rename _run_alembic_upgrade to _run_alembic_upgrade