### PR TITLE
Replace SQLite-specific datetime and upsert syntax with database-agno…

### DIFF
--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -310,11 +310,12 @@ async def signals_status(user: AuthUser = Depends(get_current_user)) -> dict:
         )
         pending_trades = (await cursor.fetchone())[0]
 
+        cutoff_24h = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
         cursor = await db.execute(
             """SELECT COUNT(*) FROM signals s
                JOIN signal_configs sc ON s.config_id = sc.id
-               WHERE s.created_at > datetime('now', '-24 hours') AND sc.user_id = ?""",
-            (user.id,),
+               WHERE s.created_at > ? AND sc.user_id = ?""",
+            (cutoff_24h, user.id),
         )
         recent_signals = (await cursor.fetchone())[0]
 

--- a/backend/download_engine.py
+++ b/backend/download_engine.py
@@ -11,6 +11,7 @@ from typing import Any
 import aiosqlite
 
 from backend.binance_client import binance_client, parse_candle, validate_candle
+from backend.config import IS_POSTGRES
 from backend.database import get_db
 
 logger = logging.getLogger(__name__)
@@ -72,11 +73,57 @@ async def _get_existing_open_times(
     return {row[0] for row in rows}
 
 
+_KLINE_COLS = [
+    "symbol",
+    "interval",
+    "open_time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "close_time",
+    "quote_asset_volume",
+    "number_of_trades",
+    "taker_buy_base_vol",
+    "taker_buy_quote_vol",
+    "ignore_field",
+    "source",
+    "downloaded_at",
+]
+
+_KLINE_UPDATE_COLS = [
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "close_time",
+    "quote_asset_volume",
+    "number_of_trades",
+    "taker_buy_base_vol",
+    "taker_buy_quote_vol",
+    "ignore_field",
+    "source",
+    "downloaded_at",
+]
+
+
 async def _upsert_candles(db: aiosqlite.Connection, candles: list[dict]) -> int:
     if not candles:
         return 0
-    await db.executemany(
-        """
+
+    if IS_POSTGRES:
+        cols = ", ".join(_KLINE_COLS)
+        placeholders = ", ".join("?" for _ in _KLINE_COLS)
+        conflict_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in _KLINE_UPDATE_COLS)
+        query = (
+            f"INSERT INTO klines ({cols}) VALUES ({placeholders}) "
+            f"ON CONFLICT (symbol, interval, open_time) DO UPDATE SET {conflict_set}"
+        )
+        params_seq = [tuple(c[col] for col in _KLINE_COLS) for c in candles]
+    else:
+        query = """
         INSERT OR REPLACE INTO klines
             (symbol, interval, open_time, open, high, low, close, volume,
              close_time, quote_asset_volume, number_of_trades,
@@ -87,9 +134,10 @@ async def _upsert_candles(db: aiosqlite.Connection, candles: list[dict]) -> int:
              :close_time, :quote_asset_volume, :number_of_trades,
              :taker_buy_base_vol, :taker_buy_quote_vol, :ignore_field,
              :source, :downloaded_at)
-        """,
-        candles,
-    )
+        """
+        params_seq = candles
+
+    await db.executemany(query, params_seq)
     await db.commit()
     return len(candles)
 

--- a/backend/metrics_engine.py
+++ b/backend/metrics_engine.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from backend.config import IS_POSTGRES
 from backend.database import get_db
 
 logger = logging.getLogger(__name__)
@@ -52,11 +53,21 @@ async def _upsert_metrics(
     """Bulk upsert (open_time, metric_name, value) tuples."""
     if not records:
         return
-    await db.executemany(
-        """
+
+    if IS_POSTGRES:
+        query = (
+            "INSERT INTO derived_metrics (symbol, interval, open_time, metric_name, value) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT (symbol, interval, open_time, metric_name) DO UPDATE SET value = EXCLUDED.value"
+        )
+    else:
+        query = """
         INSERT OR REPLACE INTO derived_metrics (symbol, interval, open_time, metric_name, value)
         VALUES (?, ?, ?, ?, ?)
-        """,
+        """
+
+    await db.executemany(
+        query,
         [(symbol, interval, ot, name, val) for ot, name, val in records],
     )
     await db.commit()


### PR DESCRIPTION
…stic queries for PostgreSQL compatibility

- Replace SQLite datetime('now', '-24 hours') with Python timedelta calculation in signals_status endpoint
- Add IS_POSTGRES conditional logic to use ON CONFLICT instead of INSERT OR REPLACE in _upsert_candles
- Define _KLINE_COLS and _KLINE_UPDATE_COLS constants for PostgreSQL dynamic query construction
- Add IS_POSTGRES conditional logic to use ON CONFLICT instead of INSERT OR REPLACE in _upsert