### PR TITLE
Add salida_por_ruptura parameter to control reversal breakout exits i…

### DIFF
--- a/backend/strategies/breakout.py
+++ b/backend/strategies/breakout.py
@@ -28,7 +28,14 @@ class BreakoutStrategy(Strategy):
             ),
             ParameterDef("habilitar_long", "bool", True, None, None, "Enable long entries"),
             ParameterDef("habilitar_short", "bool", True, None, None, "Enable short entries"),
-            ParameterDef("salida_por_ruptura", "bool", True, None, None, "Exit on reversal breakout (close vs M-candle extreme). When False, only stop-loss closes the trade."),
+            ParameterDef(
+                "salida_por_ruptura",
+                "bool",
+                True,
+                None,
+                None,
+                "Exit on reversal breakout (close vs M-candle extreme). When False, only stop-loss closes the trade.",
+            ),
             ParameterDef("coste_total_bps", "float", 10.0, 0.0, 100.0, "Round-trip transaction cost in basis points"),
         ]
 

--- a/backend/strategies/breakout.py
+++ b/backend/strategies/breakout.py
@@ -28,6 +28,7 @@ class BreakoutStrategy(Strategy):
             ),
             ParameterDef("habilitar_long", "bool", True, None, None, "Enable long entries"),
             ParameterDef("habilitar_short", "bool", True, None, None, "Enable short entries"),
+            ParameterDef("salida_por_ruptura", "bool", True, None, None, "Exit on reversal breakout (close vs M-candle extreme). When False, only stop-loss closes the trade."),
             ParameterDef("coste_total_bps", "float", 10.0, 0.0, 100.0, "Round-trip transaction cost in basis points"),
         ]
 
@@ -52,6 +53,7 @@ class BreakoutStrategy(Strategy):
         habilitar_long = bool(params.get("habilitar_long", True))
         habilitar_short = bool(params.get("habilitar_short", True))
         stop_pct = float(params.get("stop_pct", 0.02))
+        salida_por_ruptura = bool(params.get("salida_por_ruptura", True))
 
         signals: list[Signal] = []
 
@@ -73,7 +75,7 @@ class BreakoutStrategy(Strategy):
                 signals.append(Signal(action="stop_long", price=state.stop_price))
                 return signals
             # Check exit on close
-            if close < min_exit:
+            if salida_por_ruptura and close < min_exit:
                 signals.append(Signal(action="exit_long", price=close))
                 return signals
 
@@ -83,7 +85,7 @@ class BreakoutStrategy(Strategy):
                 signals.append(Signal(action="stop_short", price=state.stop_price))
                 return signals
             # Check exit on close
-            if close > max_exit:
+            if salida_por_ruptura and close > max_exit:
                 signals.append(Signal(action="exit_short", price=close))
                 return signals
 

--- a/tests/test_breakout_strategy.py
+++ b/tests/test_breakout_strategy.py
@@ -230,6 +230,44 @@ class TestExitSignals:
         signals = strat.on_candle(10, df.iloc[10], state)
         assert not any(s.action in ("exit_long", "exit_short") for s in signals)
 
+    def test_no_exit_long_when_salida_por_ruptura_disabled(self):
+        """With salida_por_ruptura=False, no exit_long even if close < min_exit."""
+        closes = [100.0] * 15
+        strat, df = _run_strategy(closes, params={"N_entrada": 5, "M_salida": 3, "salida_por_ruptura": False})
+
+        row = df.iloc[10].copy()
+        row["close"] = 98.0  # below min_exit
+        row["low"] = 98.5   # above stop_price — stop won't fire
+
+        state = PositionState(side="long", entry_price=90.0, stop_price=50.0, quantity=1.0)
+        signals = strat.on_candle(10, row, state)
+        assert not any(s.action == "exit_long" for s in signals)
+
+    def test_no_exit_short_when_salida_por_ruptura_disabled(self):
+        """With salida_por_ruptura=False, no exit_short even if close > max_exit."""
+        closes = [100.0] * 15
+        strat, df = _run_strategy(closes, params={"N_entrada": 5, "M_salida": 3, "salida_por_ruptura": False})
+
+        row = df.iloc[10].copy()
+        row["close"] = 102.0  # above max_exit
+        row["high"] = 101.5   # below stop_price — stop won't fire
+
+        state = PositionState(side="short", entry_price=110.0, stop_price=200.0, quantity=1.0)
+        signals = strat.on_candle(10, row, state)
+        assert not any(s.action == "exit_short" for s in signals)
+
+    def test_stop_still_works_when_salida_por_ruptura_disabled(self):
+        """With salida_por_ruptura=False, stop-loss still triggers normally."""
+        closes = [100.0] * 15
+        strat, df = _run_strategy(closes, params={"N_entrada": 5, "M_salida": 3, "salida_por_ruptura": False})
+
+        row = df.iloc[10].copy()
+        row["low"] = 79.0  # below stop
+
+        state = PositionState(side="long", entry_price=100.0, stop_price=80.0, quantity=1.0)
+        signals = strat.on_candle(10, row, state)
+        assert any(s.action == "stop_long" for s in signals)
+
 
 # ---------------------------------------------------------------------------
 # Stop loss signals
@@ -294,6 +332,7 @@ class TestParameterDefs:
             "modo_ejecucion",
             "habilitar_long",
             "habilitar_short",
+            "salida_por_ruptura",
             "coste_total_bps",
         }
         assert expected == names

--- a/tests/test_breakout_strategy.py
+++ b/tests/test_breakout_strategy.py
@@ -237,7 +237,7 @@ class TestExitSignals:
 
         row = df.iloc[10].copy()
         row["close"] = 98.0  # below min_exit
-        row["low"] = 98.5   # above stop_price — stop won't fire
+        row["low"] = 98.5  # above stop_price — stop won't fire
 
         state = PositionState(side="long", entry_price=90.0, stop_price=50.0, quantity=1.0)
         signals = strat.on_candle(10, row, state)
@@ -250,7 +250,7 @@ class TestExitSignals:
 
         row = df.iloc[10].copy()
         row["close"] = 102.0  # above max_exit
-        row["high"] = 101.5   # below stop_price — stop won't fire
+        row["high"] = 101.5  # below stop_price — stop won't fire
 
         state = PositionState(side="short", entry_price=110.0, stop_price=200.0, quantity=1.0)
         signals = strat.on_candle(10, row, state)


### PR DESCRIPTION
…n BreakoutStrategy

- Add salida_por_ruptura boolean parameter (default True) to enable/disable exit on reversal breakout
- Conditionally apply reversal breakout exit logic based on salida_por_ruptura flag
- When False, only stop-loss closes the trade
- Add tests for salida_por_ruptura=False scenarios (no exit_long, no exit_short, stop-loss still works)
- Update parameter definitions test to include salida_por_ruptura