### PR TITLE
style(frontend): unify SignalsPanel table presentation with reusable trade-table rules

### DIFF
--- a/frontend/src/components/SignalsPanel.jsx
+++ b/frontend/src/components/SignalsPanel.jsx
@@ -349,32 +349,32 @@ function ConfigsList({ configs, onToggle, onDelete }) {
 
   return (
     <div style={{ overflowX: 'auto' }}>
-      <table className="trade-table" style={{ width: '100%' }}>
+      <table className="trade-table">
         <thead>
           <tr>
-            <th>ID</th>
+            <th className="ta-right">ID</th>
             <th>Pair</th>
             <th>Interval</th>
             <th>Strategy</th>
-            <th>Portfolio</th>
-            <th>Stop Cross %</th>
-            <th>Active</th>
-            <th>Actions</th>
+            <th className="ta-right">Portfolio</th>
+            <th className="ta-right">Stop Cross %</th>
+            <th className="ta-center">Active</th>
+            <th className="ta-center">Actions</th>
           </tr>
         </thead>
         <tbody>
           {configs.map(c => (
             <tr key={c.id}>
-              <td style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{c.id}</td>
+              <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{c.id}</td>
               <td>{c.symbol}</td>
               <td>{c.interval}</td>
               <td>{c.strategy}</td>
-              <td>{fmtMoney(c.portfolio)}</td>
-              <td>{fmtNum(c.stop_cross_pct * 100, 1)}%</td>
-              <td>
+              <td className="ta-right num-col">{fmtMoney(c.portfolio)}</td>
+              <td className="ta-right num-col">{fmtNum(c.stop_cross_pct * 100, 1)}%</td>
+              <td className="ta-center">
                 <ToggleSwitch checked={c.active} onChange={(val) => onToggle(c.id, val)} />
               </td>
-              <td>
+              <td className="ta-center">
                 <button className="btn btn-sm btn-secondary" style={{ color: 'var(--color-danger)' }}
                   onClick={() => { if (confirm('Delete this config? Open trades will be closed.')) onDelete(c.id) }}>
                   Delete
@@ -408,19 +408,19 @@ function SignalsList({ signals }) {
       </div>
 
       <div style={{ overflowX: 'auto' }}>
-        <table className="trade-table" style={{ width: '100%' }}>
+        <table className="trade-table">
           <thead>
             <tr>
-              <th>ID</th>
+              <th className="ta-right">ID</th>
               <th>Config</th>
               <th>Symbol</th>
               <th>Side</th>
               <th>Signal Candle</th>
-              <th title="Open price of the next candle — use this as your entry on the exchange">Entry (next open) ↗</th>
-              <th title="Strategy stop-loss level — set this as your SL on the exchange">Stop Base (SL) 🛑</th>
-              <th title="Auto-close trigger = Stop Base ± stop_cross_pct. The system closes the SimTrade here automatically.">Auto-close trigger</th>
+              <th className="ta-right" title="Open price of the next candle — use this as your entry on the exchange">Entry (next open) ↗</th>
+              <th className="ta-right" title="Strategy stop-loss level — set this as your SL on the exchange">Stop Base (SL) 🛑</th>
+              <th className="ta-right" title="Auto-close trigger = Stop Base ± stop_cross_pct. The system closes the SimTrade here automatically.">Auto-close trigger</th>
               <th>Status</th>
-              <th>Sim Trade</th>
+              <th className="ta-center">Sim Trade</th>
               <th>Created</th>
             </tr>
           </thead>
@@ -433,7 +433,7 @@ function SignalsList({ signals }) {
                 : null
               return (
                 <tr key={s.id}>
-                  <td style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{s.id}</td>
+                  <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{s.id}</td>
                   <td>
                     <ConfigBadge configId={s.config_id} strategy={s.strategy} params={s.config_params} />
                   </td>
@@ -441,14 +441,14 @@ function SignalsList({ signals }) {
                   <td style={{ color: s.side === 'long' ? 'var(--color-success)' : 'var(--color-danger)', fontWeight: 700 }}>
                     {s.side?.toUpperCase()}
                   </td>
-                  <td style={{ fontFamily: 'var(--font-mono)', fontSize: '0.78rem' }}>{fmtTime(s.trigger_candle_time)}</td>
-                  <td style={{ color: entryColor, fontWeight: hasEntry ? 600 : 400 }}>
+                  <td className="num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.78rem' }}>{fmtTime(s.trigger_candle_time)}</td>
+                  <td className="ta-right num-col" style={{ color: entryColor, fontWeight: hasEntry ? 600 : 400 }}>
                     {hasEntry ? fmtNum(s.entry_price, 4) : 'Pending…'}
                   </td>
-                  <td style={{ fontFamily: 'var(--font-mono)' }}>{fmtNum(s.stop_price, 4)}</td>
-                  <td style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>{fmtNum(s.stop_trigger_price, 4)}</td>
+                  <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)' }}>{fmtNum(s.stop_price, 4)}</td>
+                  <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>{fmtNum(s.stop_trigger_price, 4)}</td>
                   <td><StatusBadge status={s.status} /></td>
-                  <td style={{ fontSize: '0.78rem' }}>
+                  <td className="ta-center" style={{ fontSize: '0.78rem' }}>
                     {s.sim_trade_id
                       ? <span>#{s.sim_trade_id}{simStatusLabel ? <span style={{ marginLeft: 4, color: 'var(--text-muted)' }}>({simStatusLabel})</span> : null}</span>
                       : '—'}
@@ -471,21 +471,21 @@ function SimTradesList({ trades, onClose }) {
   }
   return (
     <div style={{ overflowX: 'auto' }}>
-      <table className="trade-table" style={{ width: '100%' }}>
+      <table className="trade-table">
         <thead>
           <tr>
-            <th>ID</th>
+            <th className="ta-right">ID</th>
             <th>Config</th>
             <th>Symbol</th>
             <th>Side</th>
-            <th>Entry</th>
-            <th>Stop Trigger</th>
-            <th>Exit</th>
+            <th className="ta-right">Entry</th>
+            <th className="ta-right">Stop Trigger</th>
+            <th className="ta-right">Exit</th>
             <th>Reason</th>
-            <th>PnL</th>
-            <th>PnL %</th>
+            <th className="ta-right">PnL</th>
+            <th className="ta-right">PnL %</th>
             <th>Status</th>
-            <th>Actions</th>
+            <th className="ta-center">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -493,7 +493,7 @@ function SimTradesList({ trades, onClose }) {
             const pnlColor = t.pnl > 0 ? 'var(--color-success)' : t.pnl < 0 ? 'var(--color-danger)' : 'var(--text-secondary)'
             return (
               <tr key={t.id}>
-                <td style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
+                <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
                 <td>
                   <ConfigBadge configId={t.config_id} strategy={t.config_strategy} params={t.config_params} />
                 </td>
@@ -501,14 +501,14 @@ function SimTradesList({ trades, onClose }) {
                 <td style={{ color: t.side === 'long' ? 'var(--color-success)' : 'var(--color-danger)', fontWeight: 600 }}>
                   {t.side?.toUpperCase()}
                 </td>
-                <td>{t.entry_price ? fmtNum(t.entry_price, 4) : '—'}</td>
-                <td>{fmtNum(t.stop_trigger, 4)}</td>
-                <td>{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
+                <td className="ta-right num-col">{t.entry_price ? fmtNum(t.entry_price, 4) : '—'}</td>
+                <td className="ta-right num-col">{fmtNum(t.stop_trigger, 4)}</td>
+                <td className="ta-right num-col">{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
                 <td>{t.exit_reason || '—'}</td>
-                <td style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
-                <td style={{ color: pnlColor }}>{t.pnl_pct != null ? fmtNum(t.pnl_pct * 100, 2) + '%' : '—'}</td>
+                <td className="ta-right num-col" style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
+                <td className="ta-right num-col" style={{ color: pnlColor }}>{t.pnl_pct != null ? fmtNum(t.pnl_pct * 100, 2) + '%' : '—'}</td>
                 <td><StatusBadge status={t.status} /></td>
-                <td>
+                <td className="ta-center">
                   {t.status === 'open' && (
                     <button className="btn btn-sm btn-secondary" onClick={() => onClose(t.id)}>Close</button>
                   )}
@@ -678,20 +678,20 @@ function RealTradesSection() {
         <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>No real trades registered.</div>
       ) : (
         <div style={{ overflowX: 'auto' }}>
-          <table className="trade-table" style={{ width: '100%' }}>
+          <table className="trade-table">
             <thead>
               <tr>
-                <th>ID</th>
-                <th>Sim #</th>
+                <th className="ta-right">ID</th>
+                <th className="ta-right">Sim #</th>
                 <th>Symbol</th>
                 <th>Side</th>
-                <th>Entry</th>
-                <th>Exit</th>
-                <th>PnL</th>
-                <th>Fees</th>
+                <th className="ta-right">Entry</th>
+                <th className="ta-right">Exit</th>
+                <th className="ta-right">PnL</th>
+                <th className="ta-right">Fees</th>
                 <th>Status</th>
                 <th>Notes</th>
-                <th>Actions</th>
+                <th className="ta-center">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -700,21 +700,21 @@ function RealTradesSection() {
                 return (
                   <React.Fragment key={t.id}>
                   <tr>
-                    <td style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
-                    <td>{t.sim_trade_id || '—'}</td>
+                    <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
+                    <td className="ta-right num-col">{t.sim_trade_id || '—'}</td>
                     <td>{t.symbol}</td>
                     <td style={{ color: t.side === 'long' ? 'var(--color-success)' : 'var(--color-danger)', fontWeight: 600 }}>
                       {t.side?.toUpperCase()}
                     </td>
-                    <td>{fmtNum(t.entry_price, 4)}</td>
-                    <td>{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
-                    <td style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
-                    <td>{fmtNum(t.fees, 2)}</td>
+                    <td className="ta-right num-col">{fmtNum(t.entry_price, 4)}</td>
+                    <td className="ta-right num-col">{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
+                    <td className="ta-right num-col" style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
+                    <td className="ta-right num-col">{fmtNum(t.fees, 2)}</td>
                     <td><StatusBadge status={t.status} /></td>
                     <td style={{ fontSize: '0.8rem', maxWidth: 150, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                       {t.notes || '—'}
                     </td>
-                    <td>
+                    <td className="ta-center">
                       {t.status === 'open' && closingId !== t.id && (
                         <button className="btn btn-sm" onClick={() => openCloseForm(t)}
                           style={{ background: 'var(--color-warning)', color: '#000', fontSize: '0.75rem', padding: '2px 8px' }}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -502,12 +502,21 @@ select.form-control option {
   font-size: 0.82rem;
 }
 
-.data-table thead tr {
+.trade-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.data-table thead tr,
+.trade-table thead tr {
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--border-default);
 }
 
-.data-table th {
+.data-table th,
+.trade-table th {
   padding: 10px 14px;
   text-align: left;
   font-weight: 600;
@@ -520,17 +529,23 @@ select.form-control option {
   user-select: none;
 }
 
-.data-table th:hover { color: var(--text-secondary); }
+.data-table th:hover,
+.trade-table th:hover { color: var(--text-secondary); }
 
-.data-table tbody tr {
+.data-table tbody tr,
+.trade-table tbody tr {
   border-bottom: 1px solid var(--border-subtle);
   transition: background var(--transition-fast);
 }
 
-.data-table tbody tr:last-child { border-bottom: none; }
-.data-table tbody tr:hover { background: var(--bg-elevated); }
+.data-table tbody tr:last-child,
+.trade-table tbody tr:last-child { border-bottom: none; }
 
-.data-table td {
+.data-table tbody tr:hover,
+.trade-table tbody tr:hover { background: var(--bg-elevated); }
+
+.data-table td,
+.trade-table td {
   padding: 9px 14px;
   color: var(--text-secondary);
   font-family: var(--font-mono);
@@ -541,6 +556,15 @@ select.form-control option {
 .data-table td.positive { color: var(--color-success); }
 .data-table td.negative { color: var(--color-danger); }
 .data-table td.plain    { font-family: var(--font-sans); }
+
+.ta-left { text-align: left !important; }
+.ta-right { text-align: right !important; }
+.ta-center { text-align: center !important; }
+
+.num-col {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' 1;
+}
 
 /* ---- Spinner ---- */
 .spinner {


### PR DESCRIPTION
### Motivation
- Provide a single, reusable presentation baseline for all trading tables to ensure consistent sizing, borders, hover and header styles while improving numeric readability.
- Add small, semantic alignment utilities so table columns can express intent (IDs, amounts, actions) without changing data shape or behavior.
- Apply presentation-only updates to `SignalsPanel` tables to improve legibility without touching fetch/logic or data structures.

### Description
- Added a `.trade-table` block in `frontend/src/index.css` that reuses the `.data-table` visual base (`width: 100%`, `border-collapse`, typography/size, `thead`/`th`/`tbody`/`td`, hover and borders).
- Merged shared rules so `.data-table` and `.trade-table` share header/row/cell styles and kept consistent spacing/typography.
- Added semantic utility classes ` .ta-left`, `.ta-right`, `.ta-center` and `.num-col` (with `font-variant-numeric: tabular-nums`) for numeric columns.
- Updated `frontend/src/components/SignalsPanel.jsx` to remove inline width styles and apply the new classes across Configs, Signals, SimTrades and Real Trades tables for alignment and numeric formatting only, preserving all existing data/logic and actions.

### Testing
- Ran `npm --prefix frontend run lint` and it completed successfully.
- Attempted `npm --prefix frontend install` but it failed due to a registry permission (`403 Forbidden` for `oidc-client-ts`), which is an external environment issue and unrelated to the CSS/markup-only changes.
- Started the dev server with `npm --prefix frontend run dev` (Vite started), which produced an import-resolution warning for the missing dependency but did not affect the CSS/markup changes.
- Captured a visual verification screenshot via Playwright to confirm tables render with the new styles (artifact generated).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b58c5274c0832cbb94b50a7bd0a4bc)