### PR TITLE
test(live): add integration test harness for signal_engine and live_tracker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,121 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Trading Tools Laboratory — a full-stack application for downloading historical crypto data from Binance, running backtests, and monitoring live signals and simulated trades. Backend is FastAPI (Python 3.13), frontend is React 19 + Vite.
+
+## Commands
+
+### Backend
+
+```bash
+# Setup
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt       # production deps
+pip install -r requirements-dev.txt   # adds pytest, pytest-asyncio, ruff
+
+# Run
+python run.py                         # uvicorn on :8000
+
+# Lint / format
+ruff check backend/ tests/
+ruff format --check backend/ tests/
+ruff format backend/ tests/           # auto-fix
+
+# Tests
+pytest -q                             # all tests
+pytest tests/test_foo.py::test_bar -v # single test
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev    # dev server on :5173, proxied to :8000
+npm run build  # produces frontend/dist/ (served by FastAPI in prod)
+npm run lint   # ESLint
+```
+
+### Database migrations (PostgreSQL only)
+
+```bash
+DATABASE_URL=postgresql://... alembic upgrade head
+```
+
+## Architecture
+
+### Backend modules (`backend/`)
+
+| Module | Role |
+|---|---|
+| `app.py` | FastAPI factory: registers routers, CORS, static file mount, starts two background asyncio loops at lifespan |
+| `config.py` | Reads all env vars once at import; single source of truth for configuration |
+| `auth.py` | Keycloak JWT validation via JWKS. `AUTH_ENABLED=false` bypasses auth with a hard-coded admin user |
+| `database.py` | Unified `get_db()` async context manager. SQLite via `aiosqlite` (dev), PostgreSQL via `asyncpg` (prod). SQLite schema is created inline by `init_db()`; PostgreSQL runs `alembic upgrade head` automatically at startup |
+| `binance_client.py` | Async `httpx` Binance Spot API client with 429/418 rate-limit handling and exponential backoff. Singleton instance |
+| `download_engine.py` | Downloads klines in batches with upsert; tracks job progress in `download_jobs` table; `ensure_candles()` auto-fetches missing history |
+| `metrics_engine.py` | Loads klines as pandas DataFrame, computes technical indicators (SMA, EMA, ATR, Donchian, etc.), saves to `derived_metrics` |
+| `backtest_engine.py` | Vectorised backtest runner; results held in memory keyed by `backtest_id` |
+| `backtest_metrics.py` | Computes performance stats (Sharpe, drawdown, win-rate, etc.) from a trade log |
+| `signal_engine.py` | Background loop: polls active `signal_configs`, calls `ensure_candles`, runs `strategy.on_candle()`, persists signals, spawns sim trades |
+| `live_tracker.py` | Background loop: updates open `sim_trades` (entry fills, stop-outs, exits) from live Binance ticker price |
+| `strategies/base.py` | `Strategy` ABC: defines `get_parameters()`, `init()`, `on_candle()` interface shared by all strategies |
+| `strategies/breakout.py` | Breakout strategy implementation |
+| `strategies/support_resistance.py` | Support/resistance strategy implementation |
+| `api/data_routes.py` | `/api/pairs`, `/api/download`, `/api/candles`, `/api/metrics`, ... |
+| `api/backtest_routes.py` | `/api/strategies`, `/api/backtest` |
+| `api/signal_routes.py` | `/api/signals`, `/api/sim-trades`, `/api/real-trades` |
+
+### Frontend modules (`frontend/src/`)
+
+| Module | Role |
+|---|---|
+| `auth/` | OIDC login via `oidc-client-ts`; `AuthProvider` fetches config from `/api/auth/config`; `apiFetch` wraps `fetch` with Bearer token |
+| `DataManager.jsx` | Download historical data, view candles, compute metrics (admin-only) |
+| `BacktestPanel.jsx` | Configure and run backtests; shows equity chart and trade log |
+| `SignalsPanel.jsx` | Manage signal configs; view active signals and sim/real trades |
+| `EquityChart.jsx` | Recharts equity curve |
+| `TradeReviewChart.jsx` | `lightweight-charts` candlestick chart for individual trade review |
+
+### Database
+
+Two modes selected by the `DATABASE_URL` env var:
+
+- **SQLite (default/dev):** schema created inline by `init_db()`, file at `data/trading_tools.db`. Additive migrations use `PRAGMA table_info` + `ALTER TABLE` guards.
+- **PostgreSQL (prod):** Alembic runs automatically at startup. Migrations in `alembic/versions/`.
+
+Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_configs`, `signals`, `sim_trades`, `real_trades`, `notification_log`.
+
+### Strategy plugin pattern
+
+New strategies must extend `backend/strategies/base.py::Strategy`, implement `get_parameters()`, `init()`, and `on_candle()`, then be registered in the strategy registry used by `backtest_routes.py` and `signal_engine.py`.
+
+## Key Environment Variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DATABASE_URL` | unset | Full PostgreSQL URL; if unset, SQLite is used |
+| `DB_PATH` | `data/trading_tools.db` | SQLite path (ignored when `DATABASE_URL` is set) |
+| `AUTH_ENABLED` | `false` | Set `true` to enable Keycloak JWT validation |
+| `KEYCLOAK_URL` | `""` | Keycloak base URL |
+| `KEYCLOAK_REALM` | `tradingtool-dev` | Keycloak realm |
+| `KEYCLOAK_AUDIENCE` | `tradingtool-api` | JWT audience / API client ID |
+| `KEYCLOAK_FRONTEND_CLIENT_ID` | `tradingtool-web` | Returned to frontend via `/api/auth/config` |
+| `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
+
+Frontend-only (placed in `frontend/.env.development.local`, only needed to override dev defaults):
+`VITE_AUTH_ENABLED`, `VITE_KEYCLOAK_URL`, `VITE_KEYCLOAK_REALM`, `VITE_KEYCLOAK_CLIENT_ID`
+
+## Code Style
+
+- Linter/formatter: **ruff** (`ruff.toml`). `target-version = "py313"`, line-length 120.
+- Tests: **pytest** + **pytest-asyncio**. Async tests use `@pytest.mark.asyncio` directly — no project-level `conftest.py`.
+
+## Deployment
+
+- Container: multi-stage Dockerfile (Node 22 Alpine builds frontend, Python 3.13-slim runs app).
+- CD: push to `develop` → GitHub Actions builds and pushes multi-arch image to GHCR, updates `helm/env/dev.yaml` image tag for Argo CD to pick up.
+- Kubernetes: Helm chart in `helm/`; deployed to k3s via Argo CD.

--- a/tests/test_live_integration.py
+++ b/tests/test_live_integration.py
@@ -1,0 +1,886 @@
+"""Integration tests for the live trading mode (signal_engine + live_tracker).
+
+Tests the full signal lifecycle using synthetic candles and a controlled fake clock
+instead of real wall-clock time.  The approach patches _now_ms() in each module,
+pre-loads candle data into a temp SQLite DB, and calls the internal functions
+(scan_config, _fill_pending_entries, _check_intrabar_stops, _check_candle_close_exits)
+directly — the same way backtest_engine iterates over candles without asyncio.sleep.
+
+Known bugs documented here (see plan for details):
+  - Bug #5: _check_candle_close_exits labels stop-on-candle-close as 'stop_intrabar'
+  - Bug #6: strategy receives stop_base while intrabar check uses stop_trigger (different levels)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from backend.database import get_db, init_db
+from backend.download_engine import INTERVAL_MS
+from backend.live_tracker import (
+    _check_candle_close_exits,
+    _check_intrabar_stops,
+    _fill_pending_entries,
+)
+from backend.signal_engine import scan_config
+
+# ---------------------------------------------------------------------------
+# Constants — candle times are multiples of STEP_MS to ensure proper alignment
+# ---------------------------------------------------------------------------
+
+STEP_MS = INTERVAL_MS["1h"]
+BASE_TIME = (1_700_000_000_000 // STEP_MS) * STEP_MS  # aligned to 1h boundary
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_db(tmp_path):
+    db_path = str(tmp_path / "test_live_integration.db")
+    os.environ["DB_PATH"] = db_path
+    import backend.database as dbmod
+
+    dbmod.DB_PATH = __import__("pathlib").Path(db_path)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def _setup_db() -> None:
+    await init_db()
+
+
+async def _insert_config(**overrides) -> dict:
+    """Insert a signal_config with breakout defaults and return the full row dict."""
+    defaults = {
+        "symbol": "BTCUSDT",
+        "interval": "1h",
+        "strategy": "breakout",
+        "params": json.dumps(
+            {"N_entrada": 5, "M_salida": 3, "stop_pct": 0.02, "salida_por_ruptura": True},
+            sort_keys=True,
+        ),
+        "stop_cross_pct": 0.02,
+        "portfolio": 10000.0,
+        "invested_amount": None,
+        "leverage": 1.0,
+        "cost_bps": 0.0,  # no fees simplifies PnL assertions
+        "polling_interval_s": None,
+        "active": 1,
+        "last_processed_candle": 0,
+    }
+    defaults.update(overrides)
+    now = _now_iso()
+    async with get_db() as db:
+        cursor = await db.execute(
+            """INSERT INTO signal_configs
+                (symbol, interval, strategy, params, stop_cross_pct,
+                 portfolio, invested_amount, leverage, cost_bps,
+                 polling_interval_s, active, last_processed_candle,
+                 created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                defaults["symbol"],
+                defaults["interval"],
+                defaults["strategy"],
+                defaults["params"],
+                defaults["stop_cross_pct"],
+                defaults["portfolio"],
+                defaults["invested_amount"],
+                defaults["leverage"],
+                defaults["cost_bps"],
+                defaults["polling_interval_s"],
+                defaults["active"],
+                defaults["last_processed_candle"],
+                now,
+                now,
+            ),
+        )
+        await db.commit()
+        config_id = cursor.lastrowid
+        cursor2 = await db.execute("SELECT * FROM signal_configs WHERE id = ?", (config_id,))
+        row = await cursor2.fetchone()
+        cols = [d[0] for d in cursor2.description]
+    return dict(zip(cols, row, strict=False))
+
+
+def _make_flat_candles(n: int, base_time: int = BASE_TIME, price: float = 100.0) -> list[dict]:
+    """Generate n flat 1h candles starting at base_time (all times are STEP_MS multiples)."""
+    return [
+        {
+            "open_time": base_time + i * STEP_MS,
+            "open": price,
+            "high": price + 2,  # high = 102
+            "low": price - 2,  # low  = 98
+            "close": price,
+            "volume": 1000.0,
+            "close_time": base_time + i * STEP_MS + STEP_MS - 1,
+        }
+        for i in range(n)
+    ]
+
+
+def _candles_to_df(candles: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(candles)
+
+
+async def _insert_kline(candle: dict, symbol: str = "BTCUSDT", interval: str = "1h") -> None:
+    """Insert a single candle into the klines table (values stored as TEXT like Binance)."""
+    now = _now_iso()
+    async with get_db() as db:
+        await db.execute(
+            """INSERT OR REPLACE INTO klines
+                (symbol, interval, open_time, open, high, low, close, volume,
+                 close_time, quote_asset_volume, number_of_trades,
+                 taker_buy_base_vol, taker_buy_quote_vol, downloaded_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                symbol,
+                interval,
+                candle["open_time"],
+                str(candle["open"]),
+                str(candle["high"]),
+                str(candle["low"]),
+                str(candle["close"]),
+                str(candle["volume"]),
+                candle.get("close_time", candle["open_time"] + STEP_MS - 1),
+                "0",
+                0,
+                "0",
+                "0",
+                now,
+            ),
+        )
+        await db.commit()
+
+
+def _mock_binance(ticker_price: float = 110.0) -> MagicMock:
+    mock = MagicMock()
+    mock.get_ticker_price = AsyncMock(return_value=ticker_price)
+    mock.rate_limit = MagicMock()
+    mock.rate_limit.used_weight = 10
+    mock.rate_limit.weight_limit = 1200
+    return mock
+
+
+async def _get_sim_trades(status: str | None = None) -> list[dict]:
+    async with get_db() as db:
+        if status:
+            cursor = await db.execute("SELECT * FROM sim_trades WHERE status = ?", (status,))
+        else:
+            cursor = await db.execute("SELECT * FROM sim_trades")
+        rows = await cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+async def _get_signals(status: str | None = None) -> list[dict]:
+    async with get_db() as db:
+        if status:
+            cursor = await db.execute("SELECT * FROM signals WHERE status = ?", (status,))
+        else:
+            cursor = await db.execute("SELECT * FROM signals")
+        rows = await cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+def _make_breakout_df() -> tuple[pd.DataFrame, int, float, float]:
+    """
+    Build a DataFrame for a clear long breakout scenario.
+
+    Returns (df, breakout_time, stop_base, stop_trigger) where:
+      - 30 flat candles at price=100 (high=102, low=98)
+      - 1 breakout candle: close=125 > max_prev=102 → entry_long
+      - stop_base = min_prev * (1 - stop_pct) = 98 * 0.98 = 96.04
+      - stop_trigger = stop_base * (1 - stop_cross_pct) = 96.04 * 0.98 ≈ 94.12
+    """
+    flat = _make_flat_candles(30)
+    breakout_time = flat[-1]["open_time"] + STEP_MS  # index 30
+    breakout_candle = {
+        "open_time": breakout_time,
+        "open": 100.0,
+        "high": 130.0,
+        "low": 99.0,
+        "close": 125.0,
+        "volume": 2000.0,
+        "close_time": breakout_time + STEP_MS - 1,
+    }
+    df = _candles_to_df(flat + [breakout_candle])
+    stop_base = 98.0 * (1.0 - 0.02)  # = 96.04
+    stop_trigger = stop_base * (1.0 - 0.02)  # ≈ 94.12
+    return df, breakout_time, stop_base, stop_trigger
+
+
+# ---------------------------------------------------------------------------
+# Tests: signal detection (scan_config)
+# ---------------------------------------------------------------------------
+
+
+class TestSignalDetection:
+    @pytest.mark.asyncio
+    async def test_breakout_long_creates_signal_and_pending_trade(self):
+        """scan_config detects a long breakout and creates signal + sim_trade."""
+        await _setup_db()
+        config = await _insert_config()
+        df, breakout_time, stop_base, _ = _make_breakout_df()
+
+        # Fake clock: we are in the candle after the breakout (breakout is last closed)
+        fake_now = breakout_time + STEP_MS + 1
+
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await scan_config(config)
+
+        signals = await _get_signals()
+        trades = await _get_sim_trades()
+
+        assert len(signals) == 1
+        assert signals[0]["side"] == "long"
+        assert signals[0]["status"] == "pending"
+        assert signals[0]["trigger_candle_time"] == breakout_time
+        assert signals[0]["stop_price"] == pytest.approx(stop_base, abs=0.01)
+
+        assert len(trades) == 1
+        assert trades[0]["status"] == "pending_entry"
+        assert trades[0]["entry_price"] is None
+        assert trades[0]["stop_base"] == pytest.approx(stop_base, abs=0.01)
+
+    @pytest.mark.asyncio
+    async def test_last_processed_candle_updated_after_scan(self):
+        """scan_config updates last_processed_candle even when no signal fires."""
+        await _setup_db()
+        config = await _insert_config()
+
+        # Flat candles only (no breakout) — strategy produces no entry signal
+        flat = _make_flat_candles(30)
+        last_candle_time = flat[-1]["open_time"]
+        df = _candles_to_df(flat)
+        fake_now = last_candle_time + STEP_MS + 1
+
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await scan_config(config)
+
+        async with get_db() as db:
+            cursor = await db.execute("SELECT last_processed_candle FROM signal_configs WHERE id = ?", (config["id"],))
+            row = await cursor.fetchone()
+        assert row[0] == last_candle_time
+
+    @pytest.mark.asyncio
+    async def test_already_processed_candle_skips_scan(self):
+        """If last_processed_candle == last_closed, scan returns immediately."""
+        await _setup_db()
+        config = await _insert_config()
+        df, breakout_time, _, _ = _make_breakout_df()
+        fake_now = breakout_time + STEP_MS + 1
+
+        # Mark the breakout candle as already processed
+        async with get_db() as db:
+            await db.execute(
+                "UPDATE signal_configs SET last_processed_candle = ? WHERE id = ?",
+                (breakout_time, config["id"]),
+            )
+            await db.commit()
+        config["last_processed_candle"] = breakout_time
+
+        mock_load = AsyncMock()
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", mock_load),
+        ):
+            await scan_config(config)
+
+        mock_load.assert_not_called()
+        assert len(await _get_signals()) == 0
+
+    @pytest.mark.asyncio
+    async def test_skip_when_ensure_candles_not_ready(self):
+        """If ensure_candles returns False, scan is skipped and last_processed stays 0."""
+        await _setup_db()
+        config = await _insert_config()
+        df, breakout_time, _, _ = _make_breakout_df()
+        fake_now = breakout_time + STEP_MS + 1
+
+        mock_load = AsyncMock()
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=False)),
+            patch("backend.signal_engine.load_candles_df", mock_load),
+        ):
+            await scan_config(config)
+
+        mock_load.assert_not_called()
+        assert len(await _get_signals()) == 0
+
+        async with get_db() as db:
+            cursor = await db.execute("SELECT last_processed_candle FROM signal_configs WHERE id = ?", (config["id"],))
+            row = await cursor.fetchone()
+        assert row[0] == 0  # must NOT be updated when data wasn't ready
+
+    @pytest.mark.asyncio
+    async def test_skip_entry_when_active_trade_exists(self):
+        """If a sim_trade is already open for this config, no new signal is created."""
+        await _setup_db()
+        config = await _insert_config()
+        df, breakout_time, _, _ = _make_breakout_df()
+        fake_now = breakout_time + STEP_MS + 1
+
+        # Insert an existing open trade
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'active', ?)""",
+                (config["id"], BASE_TIME, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, entry_price, entry_time, quantity,
+                     created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'open',
+                           10000.0, 10000.0, 1.0, 0.0, 100.0, ?, 100.0, ?, ?)""",
+                (sig_id, config["id"], BASE_TIME + STEP_MS, now, now),
+            )
+            await db.commit()
+
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await scan_config(config)
+
+        # Only the pre-existing signal should exist
+        signals = await _get_signals()
+        assert len(signals) == 1
+        assert signals[0]["status"] == "active"  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Tests: entry fill (_fill_pending_entries)
+# ---------------------------------------------------------------------------
+
+
+class TestEntryFill:
+    @pytest.mark.asyncio
+    async def test_fills_when_next_candle_in_db(self):
+        """pending_entry trade is filled at next candle open price when kline exists."""
+        await _setup_db()
+        config = await _insert_config()
+        trigger_time = BASE_TIME
+        next_open = trigger_time + STEP_MS
+        entry_price = 125.0
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'pending', ?)""",
+                (config["id"], trigger_time, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'pending_entry',
+                           10000.0, 10000.0, 1.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], now, now),
+            )
+            await db.commit()
+
+        await _insert_kline(
+            {"open_time": next_open, "open": entry_price, "high": 128.0, "low": 123.0, "close": 126.0, "volume": 1000.0}
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        trades = await _get_sim_trades(status="open")
+        assert len(trades) == 1
+        assert trades[0]["entry_price"] == pytest.approx(entry_price)
+        assert trades[0]["entry_time"] == next_open
+        assert trades[0]["quantity"] is not None and trades[0]["quantity"] > 0
+
+    @pytest.mark.asyncio
+    async def test_does_not_fill_when_candle_missing_and_not_past_grace(self):
+        """Trade stays pending_entry when next candle is missing and grace period hasn't passed."""
+        await _setup_db()
+        config = await _insert_config()
+        trigger_time = BASE_TIME
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'pending', ?)""",
+                (config["id"], trigger_time, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'pending_entry',
+                           10000.0, 10000.0, 1.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], now, now),
+            )
+            await db.commit()
+
+        # No kline inserted; fake clock is before grace period (5s after next_open)
+        next_open = trigger_time + STEP_MS
+        fake_now = next_open + 1000  # 1s after next_open, before 5s grace
+
+        with (
+            patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.live_tracker._now_ms", return_value=fake_now),
+        ):
+            await _fill_pending_entries()
+
+        trades = await _get_sim_trades()
+        assert trades[0]["status"] == "pending_entry"
+        assert trades[0]["entry_price"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: candle-close exit (_check_candle_close_exits)
+# ---------------------------------------------------------------------------
+
+
+class TestCandleCloseExit:
+    @pytest.mark.asyncio
+    async def test_exit_signal_closes_trade_at_close_price(self):
+        """Strategy exit_long signal closes the trade at candle close price."""
+        await _setup_db()
+        config = await _insert_config()
+
+        stop_base = 96.04
+        stop_trigger = stop_base * (1.0 - 0.02)
+        entry_price = 125.0
+        entry_time = BASE_TIME + STEP_MS
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, ?, ?, 'active', ?)""",
+                (config["id"], BASE_TIME, stop_base, stop_trigger, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     entry_price, entry_time, stop_base, stop_trigger, status,
+                     portfolio, invested_amount, leverage, quantity, fees,
+                     created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', ?, ?, ?, ?, 'open',
+                           10000.0, 10000.0, 1.0, 80.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], entry_price, entry_time, stop_base, stop_trigger, now, now),
+            )
+            await db.commit()
+
+        # Build DataFrame ending with an exit candle
+        # Post-entry candles with descending lows: 120, 115, 110 (indices 32-34)
+        # min_exit at index 35 = min(120, 115, 110) = 110
+        # Exit candle close=108 < 110 → exit_long; low=105 > stop_base=96.04 → no stop
+        flat = _make_flat_candles(30)
+        breakout_t = flat[-1]["open_time"] + STEP_MS
+        candles = flat + [
+            {"open_time": breakout_t, "open": 100.0, "high": 130.0, "low": 99.0, "close": 125.0, "volume": 1000.0},
+            {
+                "open_time": breakout_t + STEP_MS,
+                "open": 125.0,
+                "high": 128.0,
+                "low": 122.0,
+                "close": 126.0,
+                "volume": 1000.0,
+            },
+            {
+                "open_time": breakout_t + 2 * STEP_MS,
+                "open": 126.0,
+                "high": 127.0,
+                "low": 120.0,
+                "close": 122.0,
+                "volume": 1000.0,
+            },
+            {
+                "open_time": breakout_t + 3 * STEP_MS,
+                "open": 122.0,
+                "high": 123.0,
+                "low": 115.0,
+                "close": 116.0,
+                "volume": 1000.0,
+            },
+            {
+                "open_time": breakout_t + 4 * STEP_MS,
+                "open": 116.0,
+                "high": 117.0,
+                "low": 110.0,
+                "close": 112.0,
+                "volume": 1000.0,
+            },
+        ]
+        exit_t = breakout_t + 5 * STEP_MS
+        exit_candle = {
+            "open_time": exit_t,
+            "open": 112.0,
+            "high": 114.0,
+            "low": 105.0,
+            "close": 108.0,
+            "volume": 1000.0,
+        }
+        df = _candles_to_df(candles + [exit_candle])
+
+        # current_open = exit_t + STEP_MS → last_closed = exit_t ✓
+        fake_now = exit_t + STEP_MS + 1
+
+        with (
+            patch("backend.live_tracker._now_ms", return_value=fake_now),
+            patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.live_tracker.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await _check_candle_close_exits()
+
+        trades = await _get_sim_trades(status="closed")
+        assert len(trades) == 1
+        assert trades[0]["exit_reason"] == "exit_signal"
+        assert trades[0]["exit_price"] == pytest.approx(108.0)
+        assert trades[0]["pnl"] < 0  # exited below entry
+
+    @pytest.mark.asyncio
+    async def test_stop_on_candle_close_fallback(self):
+        """Stop detected via candle Low triggers a close.
+
+        Known bug #5: exit_reason is labeled 'stop_intrabar' even though
+        the stop was detected on candle close, not intrabar.
+        """
+        await _setup_db()
+        config = await _insert_config()
+
+        stop_base = 96.04
+        stop_trigger = stop_base * (1.0 - 0.02)
+        entry_price = 125.0
+        entry_time = BASE_TIME + STEP_MS
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, ?, ?, 'active', ?)""",
+                (config["id"], BASE_TIME, stop_base, stop_trigger, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     entry_price, entry_time, stop_base, stop_trigger, status,
+                     portfolio, invested_amount, leverage, quantity, fees,
+                     created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', ?, ?, ?, ?, 'open',
+                           10000.0, 10000.0, 1.0, 80.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], entry_price, entry_time, stop_base, stop_trigger, now, now),
+            )
+            await db.commit()
+
+        # Stop candle: low=90 ≤ stop_base=96.04 → stop_long fires
+        flat = _make_flat_candles(30)
+        breakout_t = flat[-1]["open_time"] + STEP_MS
+        stop_t = breakout_t + STEP_MS
+        stop_candle = {
+            "open_time": stop_t,
+            "open": 125.0,
+            "high": 126.0,
+            "low": 90.0,  # low <= stop_base (96.04) → stop_long
+            "close": 97.0,
+            "volume": 1000.0,
+        }
+        df = _candles_to_df(
+            flat
+            + [
+                {"open_time": breakout_t, "open": 100.0, "high": 130.0, "low": 99.0, "close": 125.0, "volume": 1000.0},
+                stop_candle,
+            ]
+        )
+
+        fake_now = stop_t + STEP_MS + 1
+
+        with (
+            patch("backend.live_tracker._now_ms", return_value=fake_now),
+            patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.live_tracker.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await _check_candle_close_exits()
+
+        trades = await _get_sim_trades(status="closed")
+        assert len(trades) == 1
+        # Bug #5: labeled as 'stop_intrabar' even though caught on candle close
+        assert trades[0]["exit_reason"] == "stop_intrabar"
+        assert trades[0]["exit_price"] == pytest.approx(stop_trigger)
+        assert trades[0]["pnl"] < 0
+
+    @pytest.mark.asyncio
+    async def test_no_exit_when_candle_does_not_trigger(self):
+        """If neither stop nor exit condition is met, trade stays open."""
+        await _setup_db()
+        config = await _insert_config()
+
+        stop_base = 96.04
+        stop_trigger = stop_base * (1.0 - 0.02)
+        entry_price = 125.0
+        entry_time = BASE_TIME + STEP_MS
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, ?, ?, 'active', ?)""",
+                (config["id"], BASE_TIME, stop_base, stop_trigger, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     entry_price, entry_time, stop_base, stop_trigger, status,
+                     portfolio, invested_amount, leverage, quantity, fees,
+                     created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', ?, ?, ?, ?, 'open',
+                           10000.0, 10000.0, 1.0, 80.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], entry_price, entry_time, stop_base, stop_trigger, now, now),
+            )
+            await db.commit()
+
+        # Neutral candle: close=126, low=122 — neither stop nor exit triggers
+        flat = _make_flat_candles(30)
+        breakout_t = flat[-1]["open_time"] + STEP_MS
+        neutral_t = breakout_t + STEP_MS
+        neutral_candle = {
+            "open_time": neutral_t,
+            "open": 125.0,
+            "high": 128.0,
+            "low": 122.0,
+            "close": 126.0,
+            "volume": 1000.0,
+        }
+        df = _candles_to_df(
+            flat
+            + [
+                {"open_time": breakout_t, "open": 100.0, "high": 130.0, "low": 99.0, "close": 125.0, "volume": 1000.0},
+                neutral_candle,
+            ]
+        )
+
+        fake_now = neutral_t + STEP_MS + 1
+
+        with (
+            patch("backend.live_tracker._now_ms", return_value=fake_now),
+            patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.live_tracker.load_candles_df", new=AsyncMock(return_value=df)),
+        ):
+            await _check_candle_close_exits()
+
+        trades = await _get_sim_trades(status="open")
+        assert len(trades) == 1  # still open
+
+
+# ---------------------------------------------------------------------------
+# Tests: full end-to-end trade cycles
+# ---------------------------------------------------------------------------
+
+
+class TestFullTradeCycle:
+    @pytest.mark.asyncio
+    async def test_full_cycle_breakout_to_intrabar_stop(self):
+        """Complete flow: scan detects breakout → entry filled → intrabar stop fires."""
+        await _setup_db()
+        config = await _insert_config()
+        df_scan, breakout_time, stop_base, _ = _make_breakout_df()
+
+        # --- Step 1: Scan detects breakout ---
+        fake_now_scan = breakout_time + STEP_MS + 1
+
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now_scan),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", new=AsyncMock(return_value=df_scan)),
+        ):
+            await scan_config(config)
+
+        signals = await _get_signals()
+        assert len(signals) == 1 and signals[0]["side"] == "long"
+        trades = await _get_sim_trades()
+        assert len(trades) == 1 and trades[0]["status"] == "pending_entry"
+
+        # --- Step 2: Next candle opens → fill entry ---
+        next_open = breakout_time + STEP_MS
+        entry_price = 125.0
+        await _insert_kline(
+            {"open_time": next_open, "open": entry_price, "high": 128.0, "low": 122.0, "close": 126.0, "volume": 1000.0}
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        open_trades = await _get_sim_trades(status="open")
+        assert len(open_trades) == 1
+        assert open_trades[0]["entry_price"] == pytest.approx(entry_price)
+        assert open_trades[0]["quantity"] > 0
+
+        # --- Step 3: Price crosses stop_trigger → stop fired ---
+        stop_trigger = open_trades[0]["stop_trigger"]
+        below_stop = stop_trigger - 1.0
+
+        with patch("backend.live_tracker.binance_client", _mock_binance(ticker_price=below_stop)):
+            await _check_intrabar_stops()
+
+        closed = await _get_sim_trades(status="closed")
+        assert len(closed) == 1
+        assert closed[0]["exit_reason"] == "stop_intrabar"
+        assert closed[0]["exit_price"] == pytest.approx(stop_trigger)
+        assert closed[0]["pnl"] < 0
+
+    @pytest.mark.asyncio
+    async def test_full_cycle_breakout_to_exit_signal(self):
+        """Complete flow: scan detects breakout → entry filled → candle-close exit signal."""
+        await _setup_db()
+        config = await _insert_config()
+        df_scan, breakout_time, _, _ = _make_breakout_df()
+
+        # --- Step 1: Scan ---
+        fake_now_scan = breakout_time + STEP_MS + 1
+
+        with (
+            patch("backend.signal_engine._now_ms", return_value=fake_now_scan),
+            patch("backend.signal_engine.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.signal_engine.load_candles_df", new=AsyncMock(return_value=df_scan)),
+        ):
+            await scan_config(config)
+
+        # --- Step 2: Fill entry ---
+        next_open = breakout_time + STEP_MS
+        entry_price = 125.0
+        await _insert_kline(
+            {"open_time": next_open, "open": entry_price, "high": 128.0, "low": 122.0, "close": 126.0, "volume": 1000.0}
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        assert len(await _get_sim_trades(status="open")) == 1
+
+        # --- Step 3: Intrabar check does NOT fire (price above stop) ---
+        with patch("backend.live_tracker.binance_client", _mock_binance(ticker_price=120.0)):
+            await _check_intrabar_stops()
+
+        assert len(await _get_sim_trades(status="open")) == 1  # still open
+
+        # --- Step 4: Advance to exit candle ---
+        # Post-entry candles with descending lows to build up the exit trigger
+        flat = _make_flat_candles(30)
+        breakout_candle = {
+            "open_time": breakout_time,
+            "open": 100.0,
+            "high": 130.0,
+            "low": 99.0,
+            "close": 125.0,
+            "volume": 1000.0,
+        }
+        post_candles = [
+            {"open_time": next_open, "open": 125.0, "high": 128.0, "low": 122.0, "close": 126.0, "volume": 1000.0},
+            {
+                "open_time": next_open + STEP_MS,
+                "open": 126.0,
+                "high": 127.0,
+                "low": 120.0,
+                "close": 122.0,
+                "volume": 1000.0,
+            },
+            {
+                "open_time": next_open + 2 * STEP_MS,
+                "open": 122.0,
+                "high": 123.0,
+                "low": 115.0,
+                "close": 116.0,
+                "volume": 1000.0,
+            },
+            {
+                "open_time": next_open + 3 * STEP_MS,
+                "open": 116.0,
+                "high": 117.0,
+                "low": 110.0,
+                "close": 112.0,
+                "volume": 1000.0,
+            },
+        ]
+        # exit_candle: close=108 < min_exit=110, low=105 > stop_base=96.04
+        exit_t = next_open + 4 * STEP_MS
+        exit_candle = {
+            "open_time": exit_t,
+            "open": 112.0,
+            "high": 114.0,
+            "low": 105.0,
+            "close": 108.0,
+            "volume": 1000.0,
+        }
+        df_exit = _candles_to_df(flat + [breakout_candle] + post_candles + [exit_candle])
+
+        fake_now_exit = exit_t + STEP_MS + 1
+
+        with (
+            patch("backend.live_tracker._now_ms", return_value=fake_now_exit),
+            patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)),
+            patch("backend.live_tracker.load_candles_df", new=AsyncMock(return_value=df_exit)),
+        ):
+            await _check_candle_close_exits()
+
+        closed = await _get_sim_trades(status="closed")
+        assert len(closed) == 1
+        assert closed[0]["exit_reason"] == "exit_signal"
+        assert closed[0]["exit_price"] == pytest.approx(108.0)
+        assert closed[0]["pnl"] < 0


### PR DESCRIPTION
## Summary
Adds a self-contained integration test harness that exercises the core trading loop
(`signal_engine` + `live_tracker`) without requiring live market data or infinite loops.

## How it works
- Patches `_now_ms()` in both modules to control fictional time
- Pre-loads synthetic candles into a temporary SQLite DB (`tmp_path`)
- Calls internal functions directly: `scan_config`, `_fill_pending_entries`,
  `_check_intrabar_stops`, `_check_candle_close_exits`
- No new dependencies required (no `freezegun`, etc.)

## Tests (12 tests across 4 classes)
| Class | Coverage |
|---|---|
| `TestSignalDetection` | Breakout long creates signal, already-processed candle skipped, `ensure_candles=False` skips scan, active trade blocks new entry, `last_processed_candle` updated even with no signal |
| `TestEntryFill` | Fill when candle is in DB, no fill if candle missing and within 5s grace period |
| `TestCandleCloseExit` | `exit_signal` closes at close price, stop by candle Low closes, no close if no condition |
| `TestFullTradeCycle` | Full cycle breakout → fill → intrabar stop, full cycle breakout → fill → exit_signal |

## Known bugs (documented, not fixed)
Bugs are documented in test docstrings and inline comments (e.g. bug #5: incorrect
`stop_intrabar` label on candle-close stops). Can be fixed in a follow-up.

## Files
- `tests/test_live_integration.py` — test harness
- `CLAUDE.md` — codebase guidance for Claude Code