### PR TITLE
docs: expand CLAUDE.md with live-mode invariants and testing conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,11 @@ Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_conf
 
 New strategies must extend `backend/strategies/base.py::Strategy`, implement `get_parameters()`, `init()`, and `on_candle()`, then be registered in the strategy registry used by `backtest_routes.py` and `signal_engine.py`.
 
+### Live-mode invariants
+
+- **Sim-trade lifecycle**: `pending_entry` → `open` → `closed`. On close, `exit_reason` ∈ `{stop_intrabar, stop_candle, exit_signal, manual, config_deleted}`.
+- **Stop levels**: `stop_base` is the strategy's raw stop. `stop_trigger = stop_base × (1 − stop_cross_pct)` for longs, `× (1 + stop_cross_pct)` for shorts. Both the intrabar ticker check and the candle-close strategy state use `stop_trigger` so the two paths fire at the same price.
+
 ## Key Environment Variables
 
 | Variable | Default | Notes |
@@ -113,6 +118,13 @@ Frontend-only (placed in `frontend/.env.development.local`, only needed to overr
 
 - Linter/formatter: **ruff** (`ruff.toml`). `target-version = "py313"`, line-length 120.
 - Tests: **pytest** + **pytest-asyncio**. Async tests use `@pytest.mark.asyncio` directly — no project-level `conftest.py`.
+
+## Testing conventions
+
+- **No shared `conftest.py`**: each test file defines its own `_use_temp_db` autouse fixture (sets `DB_PATH` env var *and* patches `backend.database.DB_PATH`) plus local `_insert_config` / `_setup_db` helpers. Follow this pattern in new tests.
+- **Time-travel tests**: `signal_engine.py` and `live_tracker.py` each define their own `_now_ms()` (copy, not shared import). Patch both when a test spans the two modules: `patch("backend.signal_engine._now_ms", return_value=fake_ms)` and `patch("backend.live_tracker._now_ms", ...)`.
+- **Patch imported functions at the consumer**: `ensure_candles` and `load_candles_df` are imported into `signal_engine` / `live_tracker`. Patch `backend.signal_engine.ensure_candles` (the binding in that module), not `backend.download_engine.ensure_candles`.
+- `klines` numeric fields are stored as TEXT strings (Binance format) — cast with `str()` on insert, `float()` on read.
 
 ## Deployment
 


### PR DESCRIPTION
Adds two new sections:

* Live-mode invariants: documents sim-trade lifecycle states, exit_reason values, and stop_base vs stop_trigger semantics (both paths use stop_trigger to ensure consistent exit prices).

* Testing conventions: explains the no-shared-conftest pattern (each test file defines its own _use_temp_db fixture), time-travel patching strategy for _now_ms() across signal_engine and live_tracker, patch-at-consumer