### PR TITLE
feat(notifications): Telegram alerts subsystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ alembic/__pycache__/
 
 # helm
 helm/env/secrets.yaml
+
+# Claude
+.claude

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,17 @@ DATABASE_URL=postgresql://... alembic upgrade head
 | `backtest_engine.py` | Vectorised backtest runner; results held in memory keyed by `backtest_id` |
 | `backtest_metrics.py` | Computes performance stats (Sharpe, drawdown, win-rate, etc.) from a trade log |
 | `signal_engine.py` | Background loop: polls active `signal_configs`, calls `ensure_candles`, runs `strategy.on_candle()`, persists signals, spawns sim trades |
-| `live_tracker.py` | Background loop: updates open `sim_trades` (entry fills, stop-outs, exits) from live Binance ticker price |
+| `live_tracker.py` | Background loop: updates open `sim_trades` (entry fills, stop-outs, exits) from live Binance ticker price; emits user-facing notifications via `notifications.notify_event` |
+| `notifications.py` | Unified dispatcher for user-facing trade events. Resolves the recipient from `signal_configs.user_id`, honours the per-config `telegram_enabled` toggle, dedupes through `notification_log (event_type, reference_type, reference_id, channel)` and sends Telegram when all gates pass. Supported event types: `entry`, `exit_signal`, `stop_hit`, `stop_moved` (reserved for trailing-stop feature — see corresponding GitHub issue) |
+| `telegram_client.py` | Thin async Telegram Bot API client (`send_message`, `set_webhook`, MarkdownV2 `escape_md`). No-op when `TELEGRAM_BOT_TOKEN` is unset — safe default for tests and CI |
 | `strategies/base.py` | `Strategy` ABC: defines `get_parameters()`, `init()`, `on_candle()` interface shared by all strategies |
 | `strategies/breakout.py` | Breakout strategy implementation |
 | `strategies/support_resistance.py` | Support/resistance strategy implementation |
 | `api/data_routes.py` | `/api/pairs`, `/api/download`, `/api/candles`, `/api/metrics`, ... |
 | `api/backtest_routes.py` | `/api/strategies`, `/api/backtest` |
-| `api/signal_routes.py` | `/api/signals`, `/api/sim-trades`, `/api/real-trades` |
+| `api/signal_routes.py` | `/api/signals`, `/api/sim-trades`, `/api/real-trades`. `signal_configs` payloads accept `telegram_enabled` on create/patch |
+| `api/profile_routes.py` | `/api/profile/telegram` — link-token issuance, status, unlink |
+| `api/telegram_routes.py` | `/api/telegram/webhook/{secret}` — **not** protected by Keycloak; authenticated via path secret + `X-Telegram-Bot-Api-Secret-Token` header |
 
 ### Frontend modules (`frontend/src/`)
 
@@ -76,7 +80,8 @@ DATABASE_URL=postgresql://... alembic upgrade head
 | `auth/` | OIDC login via `oidc-client-ts`; `AuthProvider` fetches config from `/api/auth/config`; `apiFetch` wraps `fetch` with Bearer token |
 | `DataManager.jsx` | Download historical data, view candles, compute metrics (admin-only) |
 | `BacktestPanel.jsx` | Configure and run backtests; shows equity chart and trade log |
-| `SignalsPanel.jsx` | Manage signal configs; view active signals and sim/real trades |
+| `SignalsPanel.jsx` | Manage signal configs (incl. per-config Telegram toggle); view active signals and sim/real trades |
+| `ProfilePanel.jsx` | User profile page; Telegram linking flow (generate link → user pastes deep-link → poll until bound) |
 | `EquityChart.jsx` | Recharts equity curve |
 | `TradeReviewChart.jsx` | `lightweight-charts` candlestick chart for individual trade review |
 
@@ -87,11 +92,23 @@ Two modes selected by the `DATABASE_URL` env var:
 - **SQLite (default/dev):** schema created inline by `init_db()`, file at `data/trading_tools.db`. Additive migrations use `PRAGMA table_info` + `ALTER TABLE` guards.
 - **PostgreSQL (prod):** Alembic runs automatically at startup. Migrations in `alembic/versions/`.
 
-Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_configs`, `signals`, `sim_trades`, `real_trades`, `notification_log`.
+Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_configs`, `signals`, `sim_trades`, `real_trades`, `notification_log`, `telegram_link_tokens`.
+
+Keep the inline SQLite migration in `init_db()` and the Alembic revision in lockstep — both must produce the same final schema. Any new column/table lands in both or neither.
 
 ### Strategy plugin pattern
 
 New strategies must extend `backend/strategies/base.py::Strategy`, implement `get_parameters()`, `init()`, and `on_candle()`, then be registered in the strategy registry used by `backtest_routes.py` and `signal_engine.py`.
+
+### Telegram notifications
+
+One shared bot per deployment. Each user links their own chat on first use:
+
+1. Frontend profile page calls `POST /api/profile/telegram/link-token` → backend generates a one-time token (15 min TTL) and returns a `https://t.me/<bot>?start=<token>` deep-link.
+2. User opens the link and sends `/start <token>` to the bot.
+3. Telegram POSTs the update to `/api/telegram/webhook/{secret}`; the webhook consumes the token and stores `telegram_chat_id` / `telegram_username` on the user row.
+
+Outbound alerts flow through a single entry point — `notifications.notify_event` — which live_tracker calls at four sites (entry fill, exit signal, intrabar stop, candle-close stop). The dispatcher filters by the per-config `telegram_enabled` toggle + the user's linked chat, and dedupes on `notification_log (event_type, reference_type, reference_id, channel)`. The whole subsystem is inert (no HTTP, no reply) whenever `TELEGRAM_BOT_TOKEN` is empty — this is the invariant that keeps tests and CI green without mocking the network.
 
 ## Key Environment Variables
 
@@ -105,6 +122,11 @@ New strategies must extend `backend/strategies/base.py::Strategy`, implement `ge
 | `KEYCLOAK_AUDIENCE` | `tradingtool-api` | JWT audience / API client ID |
 | `KEYCLOAK_FRONTEND_CLIENT_ID` | `tradingtool-web` | Returned to frontend via `/api/auth/config` |
 | `CORS_ORIGINS` | `*` | Comma-separated allowed origins |
+| `PUBLIC_BASE_URL` | `""` | Used to build "Ver trade" links in outbound Telegram messages |
+| `TELEGRAM_BOT_TOKEN` | `""` | Bot API token. **When empty, the whole Telegram subsystem is no-op** — tests and CI rely on this |
+| `TELEGRAM_BOT_USERNAME` | `""` | Bot username (no `@`); used to build the `https://t.me/<bot>?start=<token>` deep-link in link-token responses |
+| `TELEGRAM_WEBHOOK_SECRET` | `""` | Secret embedded in the webhook path and verified in the `X-Telegram-Bot-Api-Secret-Token` header |
+| `TELEGRAM_WEBHOOK_URL` | `""` | If set (together with the bot token), `setWebhook` is invoked once at app lifespan startup |
 
 Frontend-only (placed in `frontend/.env.development.local`, only needed to override dev defaults):
 `VITE_AUTH_ENABLED`, `VITE_KEYCLOAK_URL`, `VITE_KEYCLOAK_REALM`, `VITE_KEYCLOAK_CLIENT_ID`

--- a/alembic/versions/003_telegram_notifications.py
+++ b/alembic/versions/003_telegram_notifications.py
@@ -1,0 +1,97 @@
+"""Telegram notifications: user chat link, per-config toggle, channel in notification_log
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-23
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: Union[str, None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- users: Telegram link columns ---------------------------------------
+    op.add_column("users", sa.Column("telegram_chat_id", sa.BigInteger, nullable=True))
+    op.add_column("users", sa.Column("telegram_username", sa.Text, nullable=True))
+    op.add_column("users", sa.Column("telegram_linked_at", sa.Text, nullable=True))
+    # Partial unique index: one chat_id per user, many NULLs allowed.
+    op.create_index(
+        "idx_users_telegram_chat_id",
+        "users",
+        ["telegram_chat_id"],
+        unique=True,
+        postgresql_where=sa.text("telegram_chat_id IS NOT NULL"),
+    )
+
+    # --- signal_configs: per-alert Telegram toggle --------------------------
+    op.add_column(
+        "signal_configs",
+        sa.Column("telegram_enabled", sa.Integer, server_default="0", nullable=False),
+    )
+
+    # --- telegram_link_tokens: opaque codes pasted via "/start <token>" -----
+    op.create_table(
+        "telegram_link_tokens",
+        sa.Column("token", sa.Text, primary_key=True),
+        sa.Column(
+            "user_id",
+            sa.Integer,
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.Text, nullable=False),
+        sa.Column("expires_at", sa.Text, nullable=False),
+        sa.Column("used_at", sa.Text, nullable=True),
+    )
+    op.create_index(
+        "idx_telegram_link_tokens_user",
+        "telegram_link_tokens",
+        ["user_id"],
+    )
+
+    # --- notification_log: add channel + user_id, swap unique constraint ----
+    op.add_column(
+        "notification_log",
+        sa.Column("channel", sa.Text, server_default="internal", nullable=False),
+    )
+    op.add_column(
+        "notification_log",
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=True),
+    )
+    op.drop_constraint("idx_notification_dedup", "notification_log", type_="unique")
+    op.create_unique_constraint(
+        "idx_notification_dedup",
+        "notification_log",
+        ["event_type", "reference_type", "reference_id", "channel"],
+    )
+
+
+def downgrade() -> None:
+    # Reverse of upgrade, strict inverse order.
+    op.drop_constraint("idx_notification_dedup", "notification_log", type_="unique")
+    op.create_unique_constraint(
+        "idx_notification_dedup",
+        "notification_log",
+        ["event_type", "reference_type", "reference_id"],
+    )
+    op.drop_column("notification_log", "user_id")
+    op.drop_column("notification_log", "channel")
+
+    op.drop_index("idx_telegram_link_tokens_user", table_name="telegram_link_tokens")
+    op.drop_table("telegram_link_tokens")
+
+    op.drop_column("signal_configs", "telegram_enabled")
+
+    op.drop_index("idx_users_telegram_chat_id", table_name="users")
+    op.drop_column("users", "telegram_linked_at")
+    op.drop_column("users", "telegram_username")
+    op.drop_column("users", "telegram_chat_id")

--- a/backend/api/profile_routes.py
+++ b/backend/api/profile_routes.py
@@ -1,0 +1,114 @@
+"""User profile routes — Telegram linking lives here.
+
+Flow (see ``telegram_routes.py`` for the webhook side):
+
+1. UI calls ``POST /api/profile/telegram/link-token`` → backend returns an
+   opaque token + the deep-link ``https://t.me/<bot>?start=<token>``.
+2. User opens the link on Telegram and sends ``/start <token>`` to the bot.
+3. Telegram POSTs the update to our webhook, which marks the token as used
+   and stores ``telegram_chat_id`` / ``telegram_username`` on the user row.
+4. UI polls ``GET /api/profile/telegram`` until ``linked=true``.
+"""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend.auth import AuthUser, get_current_user
+from backend.config import TELEGRAM_BOT_USERNAME, TELEGRAM_ENABLED
+from backend.database import get_db
+
+router = APIRouter(tags=["profile"])
+
+_LINK_TOKEN_TTL = timedelta(minutes=15)
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@router.get("/profile/telegram")
+async def get_telegram_status(user: AuthUser = Depends(get_current_user)) -> dict:
+    """Return the current user's Telegram link status."""
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT telegram_chat_id, telegram_username, telegram_linked_at FROM users WHERE id = ?",
+            (user.id,),
+        )
+        row = await cursor.fetchone()
+
+    chat_id = row[0] if row else None
+    username = row[1] if row else None
+    linked_at = row[2] if row else None
+
+    return {
+        "linked": chat_id is not None,
+        "telegram_username": username,
+        "linked_at": linked_at,
+        "bot_configured": TELEGRAM_ENABLED,
+        "bot_username": TELEGRAM_BOT_USERNAME or None,
+    }
+
+
+@router.post("/profile/telegram/link-token")
+async def create_link_token(user: AuthUser = Depends(get_current_user)) -> dict:
+    """Generate a one-time token the user can send to the bot as ``/start <token>``."""
+    if not TELEGRAM_ENABLED:
+        raise HTTPException(
+            503,
+            "Telegram bot is not configured on this server",
+        )
+    if not TELEGRAM_BOT_USERNAME:
+        # Without a username the deep-link cannot be built.
+        raise HTTPException(
+            503,
+            "Telegram bot username is not configured on this server",
+        )
+
+    token = secrets.token_urlsafe(18)
+    now = datetime.now(UTC)
+    expires = now + _LINK_TOKEN_TTL
+
+    async with get_db() as db:
+        # Purge any previous unused tokens for this user so only the latest is valid.
+        await db.execute(
+            "DELETE FROM telegram_link_tokens WHERE user_id = ? AND used_at IS NULL",
+            (user.id,),
+        )
+        await db.execute(
+            """INSERT INTO telegram_link_tokens
+                (token, user_id, created_at, expires_at)
+               VALUES (?, ?, ?, ?)""",
+            (token, user.id, now.isoformat(), expires.isoformat()),
+        )
+        await db.commit()
+
+    return {
+        "token": token,
+        "expires_at": expires.isoformat(),
+        "deep_link": f"https://t.me/{TELEGRAM_BOT_USERNAME}?start={token}",
+        "bot_username": TELEGRAM_BOT_USERNAME,
+    }
+
+
+@router.delete("/profile/telegram")
+async def unlink_telegram(user: AuthUser = Depends(get_current_user)) -> dict:
+    """Unlink the user's Telegram chat and invalidate any pending link tokens."""
+    async with get_db() as db:
+        await db.execute(
+            """UPDATE users
+               SET telegram_chat_id = NULL,
+                   telegram_username = NULL,
+                   telegram_linked_at = NULL
+               WHERE id = ?""",
+            (user.id,),
+        )
+        await db.execute(
+            "DELETE FROM telegram_link_tokens WHERE user_id = ?",
+            (user.id,),
+        )
+        await db.commit()
+    return {"linked": False}

--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -35,6 +35,7 @@ class SignalConfigCreate(BaseModel):
     leverage: float | None = None
     cost_bps: float = 10.0
     polling_interval_s: int | None = None
+    telegram_enabled: bool = False
 
 
 class SignalConfigPatch(BaseModel):
@@ -45,6 +46,7 @@ class SignalConfigPatch(BaseModel):
     leverage: float | None = None
     cost_bps: float | None = None
     polling_interval_s: int | None = None
+    telegram_enabled: bool | None = None
 
 
 class RealTradeCreate(BaseModel):
@@ -99,9 +101,9 @@ async def create_signal_config(
                 """INSERT INTO signal_configs
                     (user_id, symbol, interval, strategy, params, stop_cross_pct,
                      portfolio, invested_amount, leverage, cost_bps,
-                     polling_interval_s, active, last_processed_candle,
+                     polling_interval_s, active, telegram_enabled, last_processed_candle,
                      created_at, updated_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 0, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, 0, ?, ?)""",
                 (
                     user.id,
                     req.symbol.upper(),
@@ -114,6 +116,7 @@ async def create_signal_config(
                     req.leverage,
                     req.cost_bps,
                     req.polling_interval_s,
+                    1 if req.telegram_enabled else 0,
                     now,
                     now,
                 ),
@@ -151,6 +154,7 @@ async def list_signal_configs(
         c = dict(zip(cols, row, strict=False))
         c["params"] = json.loads(c["params"]) if isinstance(c["params"], str) else c["params"]
         c["active"] = bool(c["active"])
+        c["telegram_enabled"] = bool(c.get("telegram_enabled"))
         configs.append(c)
     return {"configs": configs}
 
@@ -186,6 +190,9 @@ async def patch_signal_config(
     if req.polling_interval_s is not None:
         fields.append("polling_interval_s = ?")
         values.append(req.polling_interval_s)
+    if req.telegram_enabled is not None:
+        fields.append("telegram_enabled = ?")
+        values.append(1 if req.telegram_enabled else 0)
 
     if not fields:
         raise HTTPException(400, "No fields to update")

--- a/backend/api/telegram_routes.py
+++ b/backend/api/telegram_routes.py
@@ -1,0 +1,156 @@
+"""Telegram webhook endpoint.
+
+Exposed *without* Keycloak auth because Telegram itself calls it. Two layers of
+authentication protect the endpoint:
+
+1. The URL path embeds ``TELEGRAM_WEBHOOK_SECRET`` — only someone who knows the
+   secret can hit the route.
+2. Telegram also echoes the same secret back in the
+   ``X-Telegram-Bot-Api-Secret-Token`` header (passed to ``setWebhook``), which
+   we verify on every request.
+
+The only user-facing command we handle is ``/start <token>``. All other
+messages are politely acknowledged so the user knows the bot is alive.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Header, HTTPException, Request
+
+from backend.config import TELEGRAM_ENABLED, TELEGRAM_WEBHOOK_SECRET
+from backend.database import get_db
+from backend.telegram_client import send_message
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["telegram"])
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def _handle_start(chat_id: int, telegram_username: str | None, token: str) -> str:
+    """Consume a link token and bind the chat to the owning user.
+
+    Returns the message text to send back to the user.
+    """
+    now = _now_iso()
+    async with get_db() as db:
+        cursor = await db.execute(
+            """SELECT user_id, expires_at, used_at
+               FROM telegram_link_tokens WHERE token = ?""",
+            (token,),
+        )
+        row = await cursor.fetchone()
+
+        if row is None:
+            return "❌ Código de vinculación no válido\\. Genera uno nuevo desde tu perfil\\."
+
+        user_id = row[0]
+        expires_at = row[1]
+        used_at = row[2]
+
+        if used_at is not None:
+            return "⚠️ Este código ya fue usado\\. Genera uno nuevo si necesitas re\\-vincular\\."
+        if expires_at < now:
+            return "⏰ El código ha caducado\\. Genera uno nuevo desde tu perfil\\."
+
+        # Make sure no other user already owns this chat_id. If one does,
+        # reject — the user must unlink the other account first.
+        cursor = await db.execute(
+            "SELECT id FROM users WHERE telegram_chat_id = ? AND id != ?",
+            (chat_id, user_id),
+        )
+        if await cursor.fetchone() is not None:
+            return "⚠️ Este chat ya está vinculado a otra cuenta\\."
+
+        # Bind. Clear the telegram_* fields first in case the user was
+        # already linked to a different chat.
+        await db.execute(
+            """UPDATE users
+               SET telegram_chat_id = ?,
+                   telegram_username = ?,
+                   telegram_linked_at = ?
+               WHERE id = ?""",
+            (chat_id, telegram_username, now, user_id),
+        )
+        await db.execute(
+            "UPDATE telegram_link_tokens SET used_at = ? WHERE token = ?",
+            (now, token),
+        )
+        await db.commit()
+
+    return "✅ Vinculación completada\\. Ahora recibirás aquí las alertas de las configuraciones que tengas con Telegram activado\\."
+
+
+def _extract_start_token(text: str) -> str | None:
+    """Return the token from ``/start <token>`` or ``/start@bot <token>``."""
+    if not text:
+        return None
+    parts = text.strip().split(maxsplit=1)
+    cmd = parts[0].split("@", 1)[0]
+    if cmd != "/start":
+        return None
+    if len(parts) < 2:
+        return None
+    token = parts[1].strip()
+    return token or None
+
+
+@router.post("/telegram/webhook/{secret}")
+async def telegram_webhook(
+    secret: str,
+    request: Request,
+    x_telegram_bot_api_secret_token: str | None = Header(default=None),
+) -> dict:
+    """Receive updates from Telegram Bot API and process ``/start <token>``."""
+    if not TELEGRAM_ENABLED or not TELEGRAM_WEBHOOK_SECRET:
+        # When disabled we return 404 to hide the endpoint's existence.
+        raise HTTPException(404, "Not Found")
+
+    if secret != TELEGRAM_WEBHOOK_SECRET:
+        raise HTTPException(404, "Not Found")
+    if x_telegram_bot_api_secret_token != TELEGRAM_WEBHOOK_SECRET:
+        logger.warning("Telegram webhook: missing/wrong X-Telegram-Bot-Api-Secret-Token header")
+        raise HTTPException(401, "Unauthorized")
+
+    try:
+        update: dict[str, Any] = await request.json()
+    except Exception:
+        raise HTTPException(400, "Invalid JSON body") from None
+
+    message = update.get("message") or update.get("edited_message")
+    if not message:
+        # Non-message update (e.g. edited_message with attachment). Ignore.
+        return {"ok": True}
+
+    chat = message.get("chat") or {}
+    chat_id = chat.get("id")
+    if not isinstance(chat_id, int):
+        return {"ok": True}
+
+    from_user = message.get("from") or {}
+    telegram_username = from_user.get("username")  # may be None
+
+    text = message.get("text", "")
+    token = _extract_start_token(text)
+    if token is None:
+        # Friendly reply so the user knows the bot is alive, but do nothing.
+        await send_message(
+            chat_id,
+            (
+                "👋 Hola, soy el bot de Trading Tools\\.\n"
+                "Para vincular este chat con tu cuenta, abre tu perfil en la app "
+                "y pulsa *Vincular Telegram* — te daré un enlace\\."
+            ),
+        )
+        return {"ok": True}
+
+    reply = await _handle_start(chat_id=chat_id, telegram_username=telegram_username, token=token)
+    await send_message(chat_id, reply)
+    return {"ok": True}

--- a/backend/app.py
+++ b/backend/app.py
@@ -17,7 +17,9 @@ from starlette.responses import Response
 
 from backend.api.backtest_routes import router as backtest_router
 from backend.api.data_routes import router as data_router
+from backend.api.profile_routes import router as profile_router
 from backend.api.signal_routes import router as signal_router
+from backend.api.telegram_routes import router as telegram_router
 from backend.auth import get_current_user
 from backend.config import (
     AUTH_ENABLED,
@@ -27,10 +29,13 @@ from backend.config import (
     KEYCLOAK_FRONTEND_CLIENT_ID,
     KEYCLOAK_REALM,
     KEYCLOAK_URL,
+    TELEGRAM_ENABLED,
+    TELEGRAM_WEBHOOK_URL,
 )
 from backend.database import get_db, init_db
 from backend.live_tracker import run_live_tracker
 from backend.signal_engine import run_signal_scanner
+from backend.telegram_client import set_webhook as telegram_set_webhook
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +44,13 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     logger.info("Database backend: %s", "PostgreSQL" if IS_POSTGRES else "SQLite (ephemeral)")
     await init_db()
+
+    if TELEGRAM_ENABLED and TELEGRAM_WEBHOOK_URL:
+        logger.info("Registering Telegram webhook at %s", TELEGRAM_WEBHOOK_URL)
+        ok = await telegram_set_webhook(TELEGRAM_WEBHOOK_URL)
+        if not ok:
+            logger.warning("Telegram setWebhook call failed — check token/URL")
+
     scanner_task = asyncio.create_task(run_signal_scanner())
     tracker_task = asyncio.create_task(run_live_tracker())
     yield
@@ -75,6 +87,9 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 app.include_router(data_router, prefix="/api", dependencies=[Depends(get_current_user)])
 app.include_router(backtest_router, prefix="/api", dependencies=[Depends(get_current_user)])
 app.include_router(signal_router, prefix="/api", dependencies=[Depends(get_current_user)])
+app.include_router(profile_router, prefix="/api", dependencies=[Depends(get_current_user)])
+# Telegram webhook is authenticated via path secret + header, NOT via Keycloak.
+app.include_router(telegram_router, prefix="/api")
 
 
 @app.get("/api/auth/config", tags=["auth"])

--- a/backend/config.py
+++ b/backend/config.py
@@ -35,3 +35,18 @@ PORT: int = int(os.environ.get("PORT", "8000"))
 HOST: str = os.environ.get("HOST", "0.0.0.0")
 LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "info")
 CORS_ORIGINS: list[str] = [o.strip() for o in os.environ.get("CORS_ORIGINS", "*").split(",") if o.strip()]
+
+PUBLIC_BASE_URL: str = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
+
+# ---------------------------------------------------------------------------
+# Telegram notifications
+# ---------------------------------------------------------------------------
+# When TELEGRAM_BOT_TOKEN is empty the whole Telegram subsystem is a no-op
+# (safe default for tests, CI and deployments without a bot configured).
+
+TELEGRAM_BOT_TOKEN: str = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+TELEGRAM_BOT_USERNAME: str = os.environ.get("TELEGRAM_BOT_USERNAME", "").strip().lstrip("@")
+TELEGRAM_WEBHOOK_SECRET: str = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "").strip()
+TELEGRAM_WEBHOOK_URL: str = os.environ.get("TELEGRAM_WEBHOOK_URL", "").strip().rstrip("/")
+
+TELEGRAM_ENABLED: bool = bool(TELEGRAM_BOT_TOKEN)

--- a/backend/database.py
+++ b/backend/database.py
@@ -364,11 +364,23 @@ async def init_db() -> None:
                 event_type              TEXT    NOT NULL,
                 reference_type          TEXT    NOT NULL,
                 reference_id            INTEGER NOT NULL,
+                channel                 TEXT    NOT NULL DEFAULT 'internal',
+                user_id                 INTEGER REFERENCES users(id),
                 message                 TEXT,
                 sent_at                 TEXT    NOT NULL
             );
             CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_dedup
-                ON notification_log (event_type, reference_type, reference_id);
+                ON notification_log (event_type, reference_type, reference_id, channel);
+
+            CREATE TABLE IF NOT EXISTS telegram_link_tokens (
+                token                   TEXT    PRIMARY KEY,
+                user_id                 INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                created_at              TEXT    NOT NULL,
+                expires_at              TEXT    NOT NULL,
+                used_at                 TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_telegram_link_tokens_user
+                ON telegram_link_tokens (user_id);
         """)
         await db.commit()
 
@@ -377,11 +389,44 @@ async def init_db() -> None:
         # ------------------------------------------------------------------
         # Add user_id to signal_configs if it doesn't exist yet (existing DBs).
         cursor = await db.execute("PRAGMA table_info(signal_configs)")
-        columns = {row[1] for row in await cursor.fetchall()}
-        if "user_id" not in columns:
+        sc_columns = {row[1] for row in await cursor.fetchall()}
+        if "user_id" not in sc_columns:
             await db.execute("ALTER TABLE signal_configs ADD COLUMN user_id INTEGER REFERENCES users(id)")
+            await db.commit()
+        if "telegram_enabled" not in sc_columns:
+            await db.execute("ALTER TABLE signal_configs ADD COLUMN telegram_enabled INTEGER NOT NULL DEFAULT 0")
             await db.commit()
 
         # Ensure index exists (safe even if column was just added)
         await db.execute("CREATE INDEX IF NOT EXISTS idx_signal_configs_user ON signal_configs (user_id)")
+        await db.commit()
+
+        # --- users: Telegram link columns --------------------------------
+        cursor = await db.execute("PRAGMA table_info(users)")
+        u_columns = {row[1] for row in await cursor.fetchall()}
+        if "telegram_chat_id" not in u_columns:
+            await db.execute("ALTER TABLE users ADD COLUMN telegram_chat_id INTEGER")
+            await db.execute("ALTER TABLE users ADD COLUMN telegram_username TEXT")
+            await db.execute("ALTER TABLE users ADD COLUMN telegram_linked_at TEXT")
+            await db.commit()
+        # Unique on telegram_chat_id (SQLite allows multiple NULLs by default).
+        await db.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_telegram_chat_id ON users (telegram_chat_id)")
+        await db.commit()
+
+        # --- notification_log: channel + user_id + swap unique index -----
+        cursor = await db.execute("PRAGMA table_info(notification_log)")
+        nl_columns = {row[1] for row in await cursor.fetchall()}
+        if "channel" not in nl_columns:
+            await db.execute("ALTER TABLE notification_log ADD COLUMN channel TEXT NOT NULL DEFAULT 'internal'")
+            await db.commit()
+        if "user_id" not in nl_columns:
+            await db.execute("ALTER TABLE notification_log ADD COLUMN user_id INTEGER REFERENCES users(id)")
+            await db.commit()
+        # Replace old unique (event_type, reference_type, reference_id) with
+        # (event_type, reference_type, reference_id, channel).
+        await db.execute("DROP INDEX IF EXISTS idx_notification_dedup")
+        await db.execute(
+            "CREATE UNIQUE INDEX idx_notification_dedup "
+            "ON notification_log (event_type, reference_type, reference_id, channel)"
+        )
         await db.commit()

--- a/backend/live_tracker.py
+++ b/backend/live_tracker.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import time
@@ -13,6 +12,7 @@ from backend.binance_client import binance_client
 from backend.database import get_db
 from backend.download_engine import INTERVAL_MS, ensure_candles
 from backend.metrics_engine import load_candles_df
+from backend.notifications import notify_event
 from backend.strategies import get_strategy
 from backend.strategies.base import PositionState
 
@@ -78,7 +78,8 @@ async def _fill_pending_entries() -> None:
         cursor = await db.execute(
             """SELECT st.id, st.symbol, st.interval, st.side, st.signal_id,
                       st.invested_amount, st.portfolio, st.leverage,
-                      s.trigger_candle_time, sc.cost_bps
+                      st.stop_base, st.stop_trigger, st.config_id,
+                      s.trigger_candle_time, sc.cost_bps, sc.strategy
                FROM sim_trades st
                JOIN signals s ON st.signal_id = s.id
                JOIN signal_configs sc ON st.config_id = sc.id
@@ -161,6 +162,25 @@ async def _fill_pending_entries() -> None:
             trade["symbol"],
             entry_price,
             quantity,
+        )
+
+        await notify_event(
+            event_type="entry",
+            config_id=trade["config_id"],
+            reference_type="sim_trade",
+            reference_id=trade["id"],
+            payload={
+                "symbol": trade["symbol"],
+                "interval": trade["interval"],
+                "side": trade["side"],
+                "strategy": trade["strategy"],
+                "entry_price": entry_price,
+                "stop_price": float(trade["stop_base"]),
+                "stop_trigger": float(trade["stop_trigger"]),
+                "invested_amount": invested,
+                "leverage": float(trade["leverage"]) if trade.get("leverage") is not None else 1.0,
+                "sim_trade_id": trade["id"],
+            },
         )
 
 
@@ -252,14 +272,6 @@ async def _check_intrabar_stops() -> None:
                 "UPDATE signals SET status = 'closed' WHERE id = ?",
                 (trade["signal_id"],),
             )
-            # Log notification (dedup via unique index)
-            with contextlib.suppress(Exception):
-                await db.execute(
-                    """INSERT INTO notification_log
-                        (event_type, reference_type, reference_id, message, sent_at)
-                       VALUES ('stop_hit', 'sim_trade', ?, ?, ?)""",
-                    (trade["id"], f"Stop hit on {trade['symbol']} {trade['side']} at {exec_price:.6f}", now),
-                )
             await db.commit()
 
         logger.info(
@@ -269,6 +281,23 @@ async def _check_intrabar_stops() -> None:
             trade["symbol"],
             exec_price,
             net_pnl,
+        )
+
+        await notify_event(
+            event_type="stop_hit",
+            config_id=trade["config_id"],
+            reference_type="sim_trade",
+            reference_id=trade["id"],
+            payload={
+                "symbol": trade["symbol"],
+                "interval": trade["interval"],
+                "side": trade["side"],
+                "exit_price": exec_price,
+                "pnl": net_pnl,
+                "pnl_pct": pnl_pct,
+                "exit_reason": "stop_intrabar",
+                "sim_trade_id": trade["id"],
+            },
         )
 
         # Check liquidation
@@ -403,18 +432,28 @@ async def _check_candle_close_exits(interval: str | None = None) -> None:
                             "UPDATE signals SET status = 'closed' WHERE id = ?",
                             (trade["signal_id"],),
                         )
-                        with contextlib.suppress(Exception):
-                            await db.execute(
-                                """INSERT INTO notification_log
-                                    (event_type, reference_type, reference_id, message, sent_at)
-                                   VALUES ('exit_signal', 'sim_trade', ?, ?, ?)""",
-                                (
-                                    trade["id"],
-                                    f"Exit signal on {trade['symbol']} {trade['side']} at {exec_price:.6f}",
-                                    now,
-                                ),
-                            )
                         await db.commit()
+
+                    duration = max(
+                        (int(candle["open_time"]) - int(trade["entry_time"])) // step_ms,
+                        0,
+                    )
+                    await notify_event(
+                        event_type="exit_signal",
+                        config_id=trade["config_id"],
+                        reference_type="sim_trade",
+                        reference_id=trade["id"],
+                        payload={
+                            "symbol": trade["symbol"],
+                            "interval": trade["interval"],
+                            "side": trade["side"],
+                            "exit_price": exec_price,
+                            "pnl": net_pnl,
+                            "pnl_pct": pnl_pct,
+                            "duration_candles": duration,
+                            "sim_trade_id": trade["id"],
+                        },
+                    )
 
                     logger.info(
                         "SimTrade %d EXIT: %s %s exec=%.6f pnl=%.4f",
@@ -470,18 +509,24 @@ async def _check_candle_close_exits(interval: str | None = None) -> None:
                             "UPDATE signals SET status = 'closed' WHERE id = ?",
                             (trade["signal_id"],),
                         )
-                        with contextlib.suppress(Exception):
-                            await db.execute(
-                                """INSERT INTO notification_log
-                                    (event_type, reference_type, reference_id, message, sent_at)
-                                   VALUES ('stop_hit', 'sim_trade', ?, ?, ?)""",
-                                (
-                                    trade["id"],
-                                    f"Stop hit (candle) on {trade['symbol']} {trade['side']} at {exec_price:.6f}",
-                                    now,
-                                ),
-                            )
                         await db.commit()
+
+                    await notify_event(
+                        event_type="stop_hit",
+                        config_id=trade["config_id"],
+                        reference_type="sim_trade",
+                        reference_id=trade["id"],
+                        payload={
+                            "symbol": trade["symbol"],
+                            "interval": trade["interval"],
+                            "side": trade["side"],
+                            "exit_price": exec_price,
+                            "pnl": net_pnl,
+                            "pnl_pct": pnl_pct,
+                            "exit_reason": "stop_candle",
+                            "sim_trade_id": trade["id"],
+                        },
+                    )
 
                     logger.info(
                         "SimTrade %d STOP (candle): %s %s exec=%.6f pnl=%.4f",

--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -1,0 +1,275 @@
+"""User-facing notification dispatcher.
+
+Single entry point ``notify_event`` called by the live tracker whenever a
+trade event worth surfacing to the user happens (entry filled, exit, stop).
+
+Responsibilities:
+1. Resolve the recipient user from the signal_config.
+2. Honour the per-config ``telegram_enabled`` toggle.
+3. Deduplicate via the UNIQUE(event_type, reference_type, reference_id, channel)
+   constraint on ``notification_log``.
+4. Format and dispatch the Telegram message.
+
+Event types supported:
+    - ``entry``       : position opened (entry price known after fill)
+    - ``exit_signal`` : strategy signalled exit on candle close
+    - ``stop_hit``    : stop-loss triggered (intrabar or candle-close)
+    - ``stop_moved``  : reserved for upcoming trailing-stop support (see
+                        trailing-stop GitHub issue). No call-site yet.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from backend.config import PUBLIC_BASE_URL, TELEGRAM_ENABLED
+from backend.database import get_db
+from backend.telegram_client import escape_md, send_message
+
+logger = logging.getLogger(__name__)
+
+# All event types the dispatcher knows how to format.
+_SUPPORTED_EVENTS = {"entry", "exit_signal", "stop_hit", "stop_moved"}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def _resolve_recipient(config_id: int) -> tuple[int | None, int | None, bool]:
+    """Look up (user_id, telegram_chat_id, telegram_enabled) for a signal_config.
+
+    Returns (None, None, False) if the config has no owner — callers treat
+    this as "skip Telegram, still log internally".
+    """
+    async with get_db() as db:
+        cursor = await db.execute(
+            """SELECT sc.user_id, sc.telegram_enabled, u.telegram_chat_id
+               FROM signal_configs sc
+               LEFT JOIN users u ON u.id = sc.user_id
+               WHERE sc.id = ?""",
+            (config_id,),
+        )
+        row = await cursor.fetchone()
+    if row is None:
+        return None, None, False
+    user_id = row[0]
+    telegram_enabled = bool(row[1])
+    chat_id = row[2]
+    return user_id, chat_id, telegram_enabled
+
+
+async def _log_once(
+    *,
+    event_type: str,
+    reference_type: str,
+    reference_id: int,
+    channel: str,
+    user_id: int | None,
+    message: str,
+) -> bool:
+    """Insert a ``notification_log`` row. Returns False if a duplicate existed."""
+    try:
+        async with get_db() as db:
+            await db.execute(
+                """INSERT INTO notification_log
+                    (event_type, reference_type, reference_id, channel, user_id, message, sent_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (event_type, reference_type, reference_id, channel, user_id, message, _now_iso()),
+            )
+            await db.commit()
+        return True
+    except Exception as exc:
+        # The most common case is a UNIQUE-constraint violation (dedup) which
+        # is expected — the scanner/tracker may evaluate the same event twice
+        # across restarts. Log at DEBUG so noise stays out of production.
+        logger.debug(
+            "notification_log insert skipped (%s/%s/%s/%s): %s",
+            event_type,
+            reference_type,
+            reference_id,
+            channel,
+            exc,
+        )
+        return False
+
+
+# Formatters produce *raw* strings meant to be wrapped in backticks by the
+# caller. Inside MarkdownV2 code spans, only `\` and `` ` `` need escaping —
+# neither appears in a numeric format — so the output is safe as-is.
+
+
+def _fmt_price(value: float | None) -> str:
+    if value is None:
+        return "—"
+    if abs(value) >= 1000:
+        return f"{value:,.2f}"
+    return f"{value:.4f}"
+
+
+def _fmt_pct(value: float | None) -> str:
+    """Format a decimal ratio (0.0342 → '+3.42%'). Sign always included."""
+    if value is None:
+        return "—"
+    return f"{value * 100.0:+.2f}%"
+
+
+def _fmt_money(value: float | None, suffix: str = " USDT") -> str:
+    if value is None:
+        return "—"
+    return f"{value:+,.2f}{suffix}"
+
+
+def _trade_link(sim_trade_id: int | None) -> str | None:
+    """Build a MarkdownV2 link to the sim trade in the UI, or None."""
+    if not PUBLIC_BASE_URL or sim_trade_id is None:
+        return None
+    # escape_md on the display text only; the URL must not be escaped.
+    url = f"{PUBLIC_BASE_URL}/#sim-trade-{sim_trade_id}"
+    return f"[{escape_md('Ver trade ↗')}]({url})"
+
+
+def _format_entry(payload: dict[str, Any]) -> str:
+    leverage_str = escape_md(f"{payload.get('leverage', 1.0):.2f}")
+    lines = [
+        f"📈 *Entrada {escape_md(payload['side'].upper())}* · `{escape_md(payload['symbol'])}` · {escape_md(payload['interval'])}",
+        f"Estrategia: `{escape_md(payload['strategy'])}`",
+        f"Precio: `{_fmt_price(payload.get('entry_price'))}`",
+        f"Stop: `{_fmt_price(payload.get('stop_price'))}`  \\(auto\\-close `{_fmt_price(payload.get('stop_trigger'))}`\\)",
+        f"Invertido: `{_fmt_price(payload.get('invested_amount'))}` USDT  \\(x{leverage_str}\\)",
+    ]
+    link = _trade_link(payload.get("sim_trade_id"))
+    if link:
+        lines.append(f"🔗 {link}")
+    return "\n".join(lines)
+
+
+def _format_exit(payload: dict[str, Any]) -> str:
+    lines = [
+        f"✅ *Salida \\(estrategia\\)* · `{escape_md(payload['symbol'])}` {escape_md(payload['side'])} · {escape_md(payload['interval'])}",
+        f"Precio salida: `{_fmt_price(payload.get('exit_price'))}`",
+        f"PnL: `{_fmt_pct(payload.get('pnl_pct'))}`  \\({_fmt_money(payload.get('pnl'))}\\)",
+    ]
+    dur = payload.get("duration_candles")
+    if dur is not None:
+        lines.append(f"Duración: {escape_md(str(dur))} velas")
+    link = _trade_link(payload.get("sim_trade_id"))
+    if link:
+        lines.append(f"🔗 {link}")
+    return "\n".join(lines)
+
+
+def _format_stop(payload: dict[str, Any]) -> str:
+    lines = [
+        f"🛑 *Stop alcanzado* · `{escape_md(payload['symbol'])}` {escape_md(payload['side'])} · {escape_md(payload['interval'])}",
+        f"Precio salida: `{_fmt_price(payload.get('exit_price'))}`",
+        f"PnL: `{_fmt_pct(payload.get('pnl_pct'))}`  \\({_fmt_money(payload.get('pnl'))}\\)",
+    ]
+    reason = payload.get("exit_reason")
+    if reason:
+        lines.append(f"Tipo: `{escape_md(reason)}`")
+    link = _trade_link(payload.get("sim_trade_id"))
+    if link:
+        lines.append(f"🔗 {link}")
+    return "\n".join(lines)
+
+
+def _format_stop_moved(payload: dict[str, Any]) -> str:
+    """Reserved for trailing-stop; call-site will be added in that feature."""
+    lines = [
+        f"🎯 *Stop movido* · `{escape_md(payload['symbol'])}` {escape_md(payload['side'])} · {escape_md(payload['interval'])}",
+        f"Stop anterior: `{_fmt_price(payload.get('prev_stop'))}`",
+        f"Stop nuevo:    `{_fmt_price(payload.get('new_stop'))}`",
+    ]
+    locked = payload.get("locked_pct")
+    if locked is not None:
+        lines.append(f"Ganancia bloqueada: `{_fmt_pct(locked)}`")
+    link = _trade_link(payload.get("sim_trade_id"))
+    if link:
+        lines.append(f"🔗 {link}")
+    return "\n".join(lines)
+
+
+_FORMATTERS = {
+    "entry": _format_entry,
+    "exit_signal": _format_exit,
+    "stop_hit": _format_stop,
+    "stop_moved": _format_stop_moved,
+}
+
+
+async def notify_event(
+    *,
+    event_type: str,
+    config_id: int,
+    reference_type: str,
+    reference_id: int,
+    payload: dict[str, Any],
+) -> None:
+    """Dispatch a user-facing notification.
+
+    Always writes to ``notification_log`` (with ``channel='internal'``) so the
+    event is auditable even if no Telegram chat is linked. If the owner user
+    has a linked chat AND ``signal_configs.telegram_enabled=1``, it also
+    sends the Telegram message and logs a second row with ``channel='telegram'``.
+
+    Dedup is per (event_type, reference_type, reference_id, channel), so the
+    internal and Telegram rows coexist without colliding.
+    """
+    if event_type not in _SUPPORTED_EVENTS:
+        logger.warning("notify_event: unknown event_type=%r", event_type)
+        return
+
+    user_id, chat_id, telegram_enabled = await _resolve_recipient(config_id)
+
+    # Internal log row (always). The UI's notification list reads from here.
+    summary = (
+        f"{event_type} on {payload.get('symbol', '?')} "
+        f"{payload.get('side', '')} @ {payload.get('exit_price') or payload.get('entry_price') or '?'}"
+    )
+    await _log_once(
+        event_type=event_type,
+        reference_type=reference_type,
+        reference_id=reference_id,
+        channel="internal",
+        user_id=user_id,
+        message=summary,
+    )
+
+    # Telegram dispatch, only if all gates pass.
+    if not TELEGRAM_ENABLED:
+        return
+    if not telegram_enabled or not chat_id:
+        return
+
+    # Dedup the Telegram side before actually calling the API, so a restart
+    # or double-tick doesn't spam the user.
+    first_time = await _log_once(
+        event_type=event_type,
+        reference_type=reference_type,
+        reference_id=reference_id,
+        channel="telegram",
+        user_id=user_id,
+        message=summary,
+    )
+    if not first_time:
+        return
+
+    formatter = _FORMATTERS[event_type]
+    try:
+        text = formatter(payload)
+    except Exception as exc:
+        logger.error("notify_event: formatter failed for %s: %s", event_type, exc, exc_info=True)
+        return
+
+    ok = await send_message(chat_id, text)
+    if not ok:
+        logger.warning(
+            "notify_event: Telegram send failed for user_id=%s event=%s ref=%s/%s",
+            user_id,
+            event_type,
+            reference_type,
+            reference_id,
+        )

--- a/backend/telegram_client.py
+++ b/backend/telegram_client.py
@@ -1,0 +1,136 @@
+"""Thin async Telegram Bot API client.
+
+Only the two verbs we need: ``send_message`` (to notify users) and
+``set_webhook`` (invoked once at startup if a public URL is configured).
+
+Design:
+- If ``TELEGRAM_BOT_TOKEN`` is not set, every call becomes a logged no-op.
+  This keeps the subsystem fully inert in tests, CI and deploys without a bot.
+- Rate-limit aware: on 429 the API returns ``retry_after`` seconds; we respect
+  it once and then fail soft (the caller decides whether to retry later).
+- All network failures are caught and logged — they must never take down the
+  background tracker/scanner loops that invoke this module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from backend.config import TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET
+
+logger = logging.getLogger(__name__)
+
+_API_BASE = "https://api.telegram.org"
+_DEFAULT_TIMEOUT = 10.0
+
+
+def _api_url(method: str) -> str:
+    return f"{_API_BASE}/bot{TELEGRAM_BOT_TOKEN}/{method}"
+
+
+async def _post(method: str, payload: dict[str, Any], timeout: float = _DEFAULT_TIMEOUT) -> dict | None:
+    """POST to Telegram Bot API. Returns parsed JSON or None on error."""
+    if not TELEGRAM_BOT_TOKEN:
+        logger.debug("Telegram not configured (no TELEGRAM_BOT_TOKEN); skipping %s", method)
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(_api_url(method), json=payload)
+    except httpx.HTTPError as exc:
+        logger.warning("Telegram %s network error: %s", method, exc)
+        return None
+
+    if resp.status_code == 429:
+        # Respect Telegram's suggested retry_after once, then fail soft.
+        try:
+            retry_after = int(resp.json().get("parameters", {}).get("retry_after", 1))
+        except Exception:
+            retry_after = 1
+        retry_after = min(retry_after, 30)
+        logger.info("Telegram %s rate-limited, retrying after %ds", method, retry_after)
+        await asyncio.sleep(retry_after)
+        try:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(_api_url(method), json=payload)
+        except httpx.HTTPError as exc:
+            logger.warning("Telegram %s retry failed: %s", method, exc)
+            return None
+
+    try:
+        data = resp.json()
+    except Exception:
+        logger.warning("Telegram %s returned non-JSON (status=%d)", method, resp.status_code)
+        return None
+
+    if not data.get("ok"):
+        logger.warning(
+            "Telegram %s failed: status=%d description=%r",
+            method,
+            resp.status_code,
+            data.get("description"),
+        )
+        return None
+
+    return data
+
+
+async def send_message(
+    chat_id: int,
+    text: str,
+    *,
+    parse_mode: str = "MarkdownV2",
+    disable_web_page_preview: bool = True,
+) -> bool:
+    """Send a text message to a chat. Returns True on success."""
+    if not chat_id:
+        return False
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "text": text,
+        "disable_web_page_preview": disable_web_page_preview,
+    }
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    result = await _post("sendMessage", payload)
+    return result is not None
+
+
+async def set_webhook(url: str) -> bool:
+    """Register the bot's webhook URL. Called once at app startup."""
+    payload: dict[str, Any] = {
+        "url": url,
+        "allowed_updates": ["message"],
+    }
+    if TELEGRAM_WEBHOOK_SECRET:
+        # Telegram echoes this back in X-Telegram-Bot-Api-Secret-Token.
+        payload["secret_token"] = TELEGRAM_WEBHOOK_SECRET
+    result = await _post("setWebhook", payload)
+    return result is not None
+
+
+# ---------------------------------------------------------------------------
+# MarkdownV2 escaping
+# ---------------------------------------------------------------------------
+#
+# The MarkdownV2 spec requires escaping these characters *outside* of code
+# blocks and inline code:  _ * [ ] ( ) ~ ` > # + - = | { } . !
+# Anything not pre-escaped breaks the whole message parse on Telegram's side.
+
+_MDV2_ESCAPES = r"_*[]()~`>#+-=|{}.!\\"
+
+
+def escape_md(text: str) -> str:
+    """Escape a plain-text string for safe interpolation into MarkdownV2."""
+    if text is None:
+        return ""
+    out: list[str] = []
+    for ch in str(text):
+        if ch in _MDV2_ESCAPES:
+            out.append("\\" + ch)
+        else:
+            out.append(ch)
+    return "".join(out)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { useAuth } from './auth/useAuth'
 import DataManager from './components/DataManager'
 import BacktestPanel from './components/BacktestPanel'
 import SignalsPanel from './components/SignalsPanel'
+import ProfilePanel from './components/ProfilePanel'
 
 function App() {
   const { isAuthenticated, isLoading, login, logout, user, isAdmin } = useAuth()
@@ -12,6 +13,7 @@ function App() {
     if (isAdmin) t.push({ id: 'data', label: 'Data Manager' })
     t.push({ id: 'backtest', label: 'Backtesting' })
     t.push({ id: 'signals', label: 'Signals' })
+    t.push({ id: 'profile', label: 'Profile' })
     return t
   }, [isAdmin])
 
@@ -94,6 +96,7 @@ function App() {
         {activeTab === 'data'     && isAdmin && <DataManager />}
         {activeTab === 'backtest' && <BacktestPanel />}
         {activeTab === 'signals'  && <SignalsPanel />}
+        {activeTab === 'profile'  && <ProfilePanel />}
       </main>
     </div>
   )

--- a/frontend/src/components/ProfilePanel.jsx
+++ b/frontend/src/components/ProfilePanel.jsx
@@ -1,0 +1,182 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../auth/apiFetch'
+
+/* ---- Telegram linking section ---- */
+function TelegramLinking() {
+  const [status, setStatus] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [linkInfo, setLinkInfo] = useState(null)
+  const [error, setError] = useState(null)
+  const pollIntervalRef = useRef(null)
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await apiFetch('/api/profile/telegram')
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setStatus(data)
+      return data
+    } catch (err) {
+      setError(String(err))
+      return null
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchStatus().finally(() => setLoading(false))
+    return () => {
+      if (pollIntervalRef.current) clearInterval(pollIntervalRef.current)
+    }
+  }, [fetchStatus])
+
+  // When the user has requested a token, poll the status until linked.
+  useEffect(() => {
+    if (!linkInfo) return
+    if (status?.linked) {
+      // Already linked → stop polling and clear the deep-link.
+      setLinkInfo(null)
+      return
+    }
+    pollIntervalRef.current = setInterval(async () => {
+      const data = await fetchStatus()
+      if (data?.linked) {
+        clearInterval(pollIntervalRef.current)
+        pollIntervalRef.current = null
+        setLinkInfo(null)
+      }
+    }, 3000)
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current)
+        pollIntervalRef.current = null
+      }
+    }
+  }, [linkInfo, status?.linked, fetchStatus])
+
+  const handleGenerate = async () => {
+    setError(null)
+    try {
+      const res = await apiFetch('/api/profile/telegram/link-token', { method: 'POST' })
+      if (!res.ok) {
+        const body = await res.text()
+        throw new Error(body || `HTTP ${res.status}`)
+      }
+      const data = await res.json()
+      setLinkInfo(data)
+    } catch (err) {
+      setError(String(err))
+    }
+  }
+
+  const handleUnlink = async () => {
+    if (!confirm('¿Desvincular Telegram? Dejarás de recibir alertas hasta que vuelvas a vincular.')) return
+    setError(null)
+    try {
+      const res = await apiFetch('/api/profile/telegram', { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      await fetchStatus()
+    } catch (err) {
+      setError(String(err))
+    }
+  }
+
+  if (loading) {
+    return <div style={{ color: 'var(--text-muted)' }}>Cargando…</div>
+  }
+
+  if (!status?.bot_configured) {
+    return (
+      <div style={{
+        padding: 'var(--space-3)', border: '1px solid var(--border-default)',
+        borderRadius: 'var(--radius-sm)', color: 'var(--text-muted)', fontSize: '0.9rem',
+      }}>
+        El bot de Telegram no está configurado en este servidor. Pide al administrador que defina
+        <code style={{ margin: '0 4px' }}>TELEGRAM_BOT_TOKEN</code> y
+        <code style={{ margin: '0 4px' }}>TELEGRAM_BOT_USERNAME</code>.
+      </div>
+    )
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+      {status.linked ? (
+        <div style={{
+          padding: 'var(--space-3)', background: 'rgba(34,197,94,0.08)',
+          border: '1px solid rgba(34,197,94,0.3)', borderRadius: 'var(--radius-sm)',
+          display: 'flex', alignItems: 'center', gap: 'var(--space-3)',
+        }}>
+          <span style={{ fontSize: '1.2rem' }}>✅</span>
+          <div style={{ flex: 1 }}>
+            <div style={{ color: 'var(--color-success)', fontWeight: 600 }}>Vinculado</div>
+            <div style={{ color: 'var(--text-muted)', fontSize: '0.82rem' }}>
+              {status.telegram_username ? `@${status.telegram_username}` : 'chat vinculado'}
+              {status.linked_at ? ` · ${new Date(status.linked_at).toLocaleString()}` : ''}
+            </div>
+          </div>
+          <button className="btn btn-sm btn-secondary" onClick={handleUnlink} style={{ color: 'var(--color-danger)' }}>
+            Desvincular
+          </button>
+        </div>
+      ) : (
+        <div>
+          <p style={{ color: 'var(--text-secondary)', marginTop: 0 }}>
+            Vincula tu cuenta con Telegram para recibir alertas de entradas, salidas y stops en tus
+            configuraciones que lo tengan activado.
+          </p>
+          {!linkInfo && (
+            <button className="btn btn-primary" onClick={handleGenerate}>
+              Vincular Telegram
+            </button>
+          )}
+          {linkInfo && (
+            <div style={{
+              padding: 'var(--space-3)', background: 'var(--bg-elevated)',
+              border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)',
+              display: 'flex', flexDirection: 'column', gap: 'var(--space-2)',
+            }}>
+              <div style={{ color: 'var(--text-secondary)' }}>
+                1. Abre el enlace y pulsa <strong>START</strong> o envía <code>/start {linkInfo.token}</code>.
+              </div>
+              <a
+                href={linkInfo.deep_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn btn-primary"
+                style={{ display: 'inline-block', textDecoration: 'none' }}
+              >
+                📲 Abrir Telegram &nbsp;→&nbsp; @{linkInfo.bot_username}
+              </a>
+              <div style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>
+                2. Cuando completes el paso, esta pantalla se actualizará sola. El código caduca
+                a las {new Date(linkInfo.expires_at).toLocaleTimeString()}.
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div style={{
+          padding: '8px 12px', background: 'rgba(239,68,68,0.1)',
+          border: '1px solid rgba(239,68,68,0.25)', borderRadius: 'var(--radius-sm)',
+          color: 'var(--color-danger)', fontSize: '0.83rem',
+        }}>{error}</div>
+      )}
+    </div>
+  )
+}
+
+export default function ProfilePanel() {
+  return (
+    <div className="panel-section">
+      <div className="card">
+        <div className="card-header">
+          <span className="card-title">Telegram</span>
+        </div>
+        <div className="card-body">
+          <TelegramLinking />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SignalsPanel.jsx
+++ b/frontend/src/components/SignalsPanel.jsx
@@ -342,7 +342,7 @@ function ConfigForm({ strategies, onCreated }) {
 }
 
 /* ---- Configs list ---- */
-function ConfigsList({ configs, onToggle, onDelete }) {
+function ConfigsList({ configs, onToggle, onToggleTelegram, onDelete }) {
   if (!configs || configs.length === 0) {
     return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem', padding: 'var(--space-3)' }}>No signal configs yet.</div>
   }
@@ -359,6 +359,7 @@ function ConfigsList({ configs, onToggle, onDelete }) {
             <th className="ta-right">Portfolio</th>
             <th className="ta-right">Stop Cross %</th>
             <th className="ta-center">Active</th>
+            <th className="ta-center" title="Enviar alertas a Telegram para esta configuración">Telegram</th>
             <th className="ta-center">Actions</th>
           </tr>
         </thead>
@@ -373,6 +374,9 @@ function ConfigsList({ configs, onToggle, onDelete }) {
               <td className="ta-right num-col">{fmtNum(c.stop_cross_pct * 100, 1)}%</td>
               <td className="ta-center">
                 <ToggleSwitch checked={c.active} onChange={(val) => onToggle(c.id, val)} />
+              </td>
+              <td className="ta-center">
+                <ToggleSwitch checked={!!c.telegram_enabled} onChange={(val) => onToggleTelegram(c.id, val)} />
               </td>
               <td className="ta-center">
                 <button className="btn btn-sm btn-secondary" style={{ color: 'var(--color-danger)' }}
@@ -959,6 +963,15 @@ export default function SignalsPanel() {
     fetchConfigs()
   }
 
+  const handleToggleTelegram = async (id, telegram_enabled) => {
+    await apiFetch(`/api/signals/configs/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ telegram_enabled }),
+    })
+    fetchConfigs()
+  }
+
   const handleDelete = async (id) => {
     await apiFetch(`/api/signals/configs/${id}`, { method: 'DELETE' })
     refreshAll()
@@ -1016,7 +1029,7 @@ export default function SignalsPanel() {
           </div>
           <div className="card-body">
             <div className="section-title">Active Configurations</div>
-            <ConfigsList configs={configs} onToggle={handleToggle} onDelete={handleDelete} onRefresh={fetchConfigs} />
+            <ConfigsList configs={configs} onToggle={handleToggle} onToggleTelegram={handleToggleTelegram} onDelete={handleDelete} onRefresh={fetchConfigs} />
             <hr className="divider" />
             <div className="section-title">New Configuration</div>
             <ConfigForm strategies={strategies} onCreated={refreshAll} />

--- a/helm/env/dev.yaml
+++ b/helm/env/dev.yaml
@@ -6,10 +6,6 @@ namespace:
 config:
   LOG_LEVEL: "debug"
   AUTH_ENABLED: "true"
-  KEYCLOAK_URL: "https://keycloak-dev.liontechsolution.com"
-  KEYCLOAK_REALM: "tradingtool-dev"
-  KEYCLOAK_AUDIENCE: "tradingtool-api"
-  KEYCLOAK_FRONTEND_CLIENT_ID: "tradingtool-web"
   CORS_ORIGINS: "*"
 existingSecret: "tradingtools-secret-dev"
 cloudflareTunnel:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,280 @@
+"""Tests for backend.notifications — dispatch filtering, dedup, formatting."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.database import get_db, init_db
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_db(tmp_path):
+    db_path = str(tmp_path / "test_notif.db")
+    os.environ["DB_PATH"] = db_path
+    import backend.database as dbmod
+
+    dbmod.DB_PATH = __import__("pathlib").Path(db_path)
+    yield
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+async def _insert_user(*, chat_id: int | None = None, username: str | None = None) -> int:
+    now = _now_iso()
+    async with get_db() as db:
+        cursor = await db.execute(
+            """INSERT INTO users (keycloak_sub, email, username, roles, created_at, last_login_at,
+                                  telegram_chat_id, telegram_username, telegram_linked_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                f"test-{username or 'u'}-{chat_id or 0}",
+                f"{username or 'u'}@example.com",
+                username or "u",
+                "[]",
+                now,
+                now,
+                chat_id,
+                username,
+                now if chat_id else None,
+            ),
+        )
+        await db.commit()
+        return cursor.lastrowid
+
+
+async def _insert_config(user_id: int, *, telegram_enabled: bool = False) -> int:
+    now = _now_iso()
+    async with get_db() as db:
+        cursor = await db.execute(
+            """INSERT INTO signal_configs
+                (user_id, symbol, interval, strategy, params, stop_cross_pct, portfolio,
+                 invested_amount, leverage, cost_bps, polling_interval_s,
+                 active, telegram_enabled, last_processed_candle, created_at, updated_at)
+               VALUES (?, 'BTCUSDT', '1h', 'breakout', '{}', 0.02, 10000,
+                       NULL, 1.0, 10.0, NULL,
+                       1, ?, 0, ?, ?)""",
+            (user_id, 1 if telegram_enabled else 0, now, now),
+        )
+        await db.commit()
+        return cursor.lastrowid
+
+
+async def _count_log(channel: str) -> int:
+    async with get_db() as db:
+        cursor = await db.execute("SELECT COUNT(*) FROM notification_log WHERE channel = ?", (channel,))
+        row = await cursor.fetchone()
+    return row[0]
+
+
+@pytest.mark.asyncio
+async def test_internal_log_always_written_even_without_telegram():
+    """The internal log must be written even when Telegram isn't configured."""
+    await init_db()
+    user_id = await _insert_user(chat_id=None)
+    config_id = await _insert_config(user_id, telegram_enabled=False)
+
+    from backend.notifications import notify_event
+
+    with (
+        patch("backend.notifications.TELEGRAM_ENABLED", False),
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+    ):
+        await notify_event(
+            event_type="entry",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=999,
+            payload={
+                "symbol": "BTCUSDT",
+                "interval": "1h",
+                "side": "long",
+                "strategy": "breakout",
+                "entry_price": 65432.1,
+                "stop_price": 63200.0,
+                "stop_trigger": 62000.0,
+                "invested_amount": 1000.0,
+                "leverage": 1.0,
+                "sim_trade_id": 999,
+            },
+        )
+
+    assert await _count_log("internal") == 1
+    assert await _count_log("telegram") == 0
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skip_telegram_when_toggle_off():
+    """telegram_enabled=false → no Telegram call, even with a linked chat."""
+    await init_db()
+    user_id = await _insert_user(chat_id=42, username="user42")
+    config_id = await _insert_config(user_id, telegram_enabled=False)
+
+    from backend.notifications import notify_event
+
+    with (
+        patch("backend.notifications.TELEGRAM_ENABLED", True),
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+    ):
+        await notify_event(
+            event_type="stop_hit",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=101,
+            payload={
+                "symbol": "BTCUSDT",
+                "interval": "1h",
+                "side": "long",
+                "exit_price": 63000.0,
+                "pnl": -50.0,
+                "pnl_pct": -0.05,
+                "exit_reason": "stop_intrabar",
+                "sim_trade_id": 101,
+            },
+        )
+
+    mock_send.assert_not_called()
+    assert await _count_log("telegram") == 0
+
+
+@pytest.mark.asyncio
+async def test_skip_telegram_when_no_chat_id():
+    """Toggle on but user hasn't linked chat → skip Telegram."""
+    await init_db()
+    user_id = await _insert_user(chat_id=None)
+    config_id = await _insert_config(user_id, telegram_enabled=True)
+
+    from backend.notifications import notify_event
+
+    with (
+        patch("backend.notifications.TELEGRAM_ENABLED", True),
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+    ):
+        await notify_event(
+            event_type="exit_signal",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=202,
+            payload={
+                "symbol": "BTCUSDT",
+                "interval": "1h",
+                "side": "long",
+                "exit_price": 70000.0,
+                "pnl": 500.0,
+                "pnl_pct": 0.05,
+                "duration_candles": 12,
+                "sim_trade_id": 202,
+            },
+        )
+
+    mock_send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatches_to_telegram_when_all_gates_pass():
+    """Toggle on + chat linked + bot configured → send_message called once."""
+    await init_db()
+    user_id = await _insert_user(chat_id=12345, username="linked")
+    config_id = await _insert_config(user_id, telegram_enabled=True)
+
+    from backend.notifications import notify_event
+
+    with (
+        patch("backend.notifications.TELEGRAM_ENABLED", True),
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+    ):
+        await notify_event(
+            event_type="entry",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=303,
+            payload={
+                "symbol": "BTCUSDT",
+                "interval": "1h",
+                "side": "long",
+                "strategy": "breakout",
+                "entry_price": 65432.1,
+                "stop_price": 63200.0,
+                "stop_trigger": 62000.0,
+                "invested_amount": 1000.0,
+                "leverage": 1.0,
+                "sim_trade_id": 303,
+            },
+        )
+
+    mock_send.assert_called_once()
+    chat_arg = mock_send.call_args[0][0]
+    text_arg = mock_send.call_args[0][1]
+    assert chat_arg == 12345
+    assert "Entrada LONG" in text_arg
+    assert "BTCUSDT" in text_arg
+    assert await _count_log("internal") == 1
+    assert await _count_log("telegram") == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_prevents_double_telegram_send():
+    """Calling notify_event twice with the same ref must send only once."""
+    await init_db()
+    user_id = await _insert_user(chat_id=777)
+    config_id = await _insert_config(user_id, telegram_enabled=True)
+
+    payload = {
+        "symbol": "BTCUSDT",
+        "interval": "1h",
+        "side": "long",
+        "strategy": "breakout",
+        "entry_price": 100.0,
+        "stop_price": 98.0,
+        "stop_trigger": 97.0,
+        "invested_amount": 1000.0,
+        "leverage": 1.0,
+        "sim_trade_id": 404,
+    }
+
+    from backend.notifications import notify_event
+
+    with (
+        patch("backend.notifications.TELEGRAM_ENABLED", True),
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+    ):
+        await notify_event(
+            event_type="entry",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=404,
+            payload=payload,
+        )
+        await notify_event(
+            event_type="entry",
+            config_id=config_id,
+            reference_type="sim_trade",
+            reference_id=404,
+            payload=payload,
+        )
+
+    assert mock_send.call_count == 1
+    assert await _count_log("internal") == 1
+    assert await _count_log("telegram") == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_type_is_rejected():
+    from backend.notifications import notify_event
+
+    with patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send:
+        await notify_event(
+            event_type="bogus",
+            config_id=1,
+            reference_type="sim_trade",
+            reference_id=1,
+            payload={},
+        )
+
+    mock_send.assert_not_called()

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -1,0 +1,100 @@
+"""Tests for backend.telegram_client — escaping + no-op behaviour."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def test_escape_md_escapes_all_specials():
+    from backend.telegram_client import escape_md
+
+    out = escape_md("a.b-c_d+e=f*g|h(i)j[k]l{m}n!o#p>q~r`s")
+    # Every special character must be preceded by a backslash
+    for ch in "._-+=*|()[]{}!#>~`":
+        assert f"\\{ch}" in out, f"missing escape for {ch}"
+
+
+def test_escape_md_leaves_plain_text_untouched():
+    from backend.telegram_client import escape_md
+
+    assert escape_md("hello world 42") == "hello world 42"
+
+
+def test_escape_md_handles_none():
+    from backend.telegram_client import escape_md
+
+    assert escape_md(None) == ""
+
+
+def test_escape_md_coerces_non_strings():
+    from backend.telegram_client import escape_md
+
+    assert escape_md(3.14) == "3\\.14"
+
+
+@pytest.mark.asyncio
+async def test_send_message_is_noop_when_token_missing(monkeypatch):
+    """With TELEGRAM_BOT_TOKEN empty, no HTTP call must be made."""
+    monkeypatch.setattr("backend.telegram_client.TELEGRAM_BOT_TOKEN", "")
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock()
+
+    with patch("backend.telegram_client.httpx.AsyncClient", return_value=mock_client):
+        from backend.telegram_client import send_message
+
+        ok = await send_message(chat_id=12345, text="hi")
+
+    assert ok is False
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_posts_when_token_present(monkeypatch):
+    monkeypatch.setattr("backend.telegram_client.TELEGRAM_BOT_TOKEN", "fake-token")
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"ok": True, "result": {}})
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(return_value=resp)
+
+    with patch("backend.telegram_client.httpx.AsyncClient", return_value=mock_client):
+        from backend.telegram_client import send_message
+
+        ok = await send_message(chat_id=12345, text="hi")
+
+    assert ok is True
+    mock_client.post.assert_called_once()
+    # Confirm chat_id and text made it into the payload
+    _args, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["chat_id"] == 12345
+    assert kwargs["json"]["text"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_send_message_handles_non_ok(monkeypatch):
+    monkeypatch.setattr("backend.telegram_client.TELEGRAM_BOT_TOKEN", "fake-token")
+
+    resp = MagicMock()
+    resp.status_code = 400
+    resp.json = MagicMock(return_value={"ok": False, "description": "bad chat"})
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(return_value=resp)
+
+    with patch("backend.telegram_client.httpx.AsyncClient", return_value=mock_client):
+        from backend.telegram_client import send_message
+
+        ok = await send_message(chat_id=12345, text="hi")
+
+    assert ok is False

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -1,0 +1,250 @@
+"""Tests for backend.api.telegram_routes — /start <token> → chat_id stored."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.database import get_db, init_db
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_db(tmp_path):
+    db_path = str(tmp_path / "test_webhook.db")
+    os.environ["DB_PATH"] = db_path
+    import backend.database as dbmod
+
+    dbmod.DB_PATH = __import__("pathlib").Path(db_path)
+    yield
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _build_app():
+    """Build a minimal FastAPI app mounting only the telegram router.
+
+    We avoid importing backend.app so the lifespan (background tasks, Alembic)
+    doesn't try to start.
+    """
+    # Import after monkeypatched config to ensure the router picks it up.
+    from backend.api import telegram_routes as tg_routes
+
+    app = FastAPI()
+    app.include_router(tg_routes.router, prefix="/api")
+    return app
+
+
+async def _insert_user(username: str = "alice") -> int:
+    now = _now_iso()
+    async with get_db() as db:
+        cursor = await db.execute(
+            """INSERT INTO users (keycloak_sub, email, username, roles, created_at, last_login_at)
+               VALUES (?, ?, ?, '[]', ?, ?)""",
+            (f"sub-{username}", f"{username}@x.com", username, now, now),
+        )
+        await db.commit()
+        return cursor.lastrowid
+
+
+async def _issue_token(user_id: int, *, token: str = "abc123", ttl_minutes: int = 15) -> None:
+    from datetime import timedelta
+
+    now = datetime.now(UTC)
+    async with get_db() as db:
+        await db.execute(
+            """INSERT INTO telegram_link_tokens (token, user_id, created_at, expires_at)
+               VALUES (?, ?, ?, ?)""",
+            (token, user_id, now.isoformat(), (now + timedelta(minutes=ttl_minutes)).isoformat()),
+        )
+        await db.commit()
+
+
+async def _expire_token(token: str) -> None:
+    from datetime import timedelta
+
+    past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+    async with get_db() as db:
+        await db.execute(
+            "UPDATE telegram_link_tokens SET expires_at = ? WHERE token = ?",
+            (past, token),
+        )
+        await db.commit()
+
+
+def test_extract_start_token_accepts_plain():
+    from backend.api.telegram_routes import _extract_start_token
+
+    assert _extract_start_token("/start tok123") == "tok123"
+
+
+def test_extract_start_token_accepts_mentioned_bot():
+    from backend.api.telegram_routes import _extract_start_token
+
+    assert _extract_start_token("/start@mybot tok123") == "tok123"
+
+
+def test_extract_start_token_rejects_other_commands():
+    from backend.api.telegram_routes import _extract_start_token
+
+    assert _extract_start_token("/help tok") is None
+    assert _extract_start_token("hello world") is None
+    assert _extract_start_token("/start") is None
+    assert _extract_start_token("") is None
+
+
+@pytest.mark.asyncio
+async def test_webhook_requires_secret(monkeypatch):
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_ENABLED", True)
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_WEBHOOK_SECRET", "correct-secret")
+
+    await init_db()
+    app = _build_app()
+    client = TestClient(app)
+
+    # Wrong secret in path
+    resp = client.post(
+        "/api/telegram/webhook/wrong",
+        json={},
+        headers={"X-Telegram-Bot-Api-Secret-Token": "correct-secret"},
+    )
+    assert resp.status_code == 404
+
+    # Correct path, wrong header
+    resp = client.post(
+        "/api/telegram/webhook/correct-secret",
+        json={"message": {"chat": {"id": 1}, "text": "/start abc"}},
+        headers={"X-Telegram-Bot-Api-Secret-Token": "nope"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_webhook_disabled_returns_404(monkeypatch):
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_ENABLED", False)
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_WEBHOOK_SECRET", "")
+
+    await init_db()
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/api/telegram/webhook/anything",
+        json={},
+        headers={"X-Telegram-Bot-Api-Secret-Token": "anything"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_start_with_valid_token_links_chat(monkeypatch):
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_ENABLED", True)
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_WEBHOOK_SECRET", "sekret")
+
+    await init_db()
+    user_id = await _insert_user()
+    await _issue_token(user_id, token="tok_valid")
+
+    app = _build_app()
+    with patch(
+        "backend.api.telegram_routes.send_message",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        client = TestClient(app)
+        resp = client.post(
+            "/api/telegram/webhook/sekret",
+            json={
+                "message": {
+                    "chat": {"id": 98765},
+                    "from": {"username": "alice_tg"},
+                    "text": "/start tok_valid",
+                }
+            },
+            headers={"X-Telegram-Bot-Api-Secret-Token": "sekret"},
+        )
+
+    assert resp.status_code == 200
+    mock_send.assert_called()
+
+    # DB side effects: chat_id stored, token marked used.
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT telegram_chat_id, telegram_username FROM users WHERE id = ?",
+            (user_id,),
+        )
+        row = await cursor.fetchone()
+    assert row[0] == 98765
+    assert row[1] == "alice_tg"
+
+    async with get_db() as db:
+        cursor = await db.execute(
+            "SELECT used_at FROM telegram_link_tokens WHERE token = ?",
+            ("tok_valid",),
+        )
+        used_row = await cursor.fetchone()
+    assert used_row[0] is not None
+
+
+@pytest.mark.asyncio
+async def test_start_with_expired_token_rejects(monkeypatch):
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_ENABLED", True)
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_WEBHOOK_SECRET", "sekret")
+
+    await init_db()
+    user_id = await _insert_user()
+    await _issue_token(user_id, token="tok_old")
+    await _expire_token("tok_old")
+
+    app = _build_app()
+    with patch(
+        "backend.api.telegram_routes.send_message",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        client = TestClient(app)
+        resp = client.post(
+            "/api/telegram/webhook/sekret",
+            json={
+                "message": {
+                    "chat": {"id": 11111},
+                    "from": {"username": "x"},
+                    "text": "/start tok_old",
+                }
+            },
+            headers={"X-Telegram-Bot-Api-Secret-Token": "sekret"},
+        )
+
+    assert resp.status_code == 200
+    # Chat must NOT be linked
+    async with get_db() as db:
+        cursor = await db.execute("SELECT telegram_chat_id FROM users WHERE id = ?", (user_id,))
+        row = await cursor.fetchone()
+    assert row[0] is None
+    # The user still received an explanatory reply
+    mock_send.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_text_gets_friendly_reply(monkeypatch):
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_ENABLED", True)
+    monkeypatch.setattr("backend.api.telegram_routes.TELEGRAM_WEBHOOK_SECRET", "sekret")
+
+    await init_db()
+    app = _build_app()
+    with patch(
+        "backend.api.telegram_routes.send_message",
+        new=AsyncMock(return_value=True),
+    ) as mock_send:
+        client = TestClient(app)
+        resp = client.post(
+            "/api/telegram/webhook/sekret",
+            json={"message": {"chat": {"id": 77}, "from": {}, "text": "hello?"}},
+            headers={"X-Telegram-Bot-Api-Secret-Token": "sekret"},
+        )
+
+    assert resp.status_code == 200
+    mock_send.assert_called_once()


### PR DESCRIPTION
## Summary

Add a per-user, per-config Telegram notifications subsystem. When a user links their Telegram chat and toggles the new flag on a signal config, they receive a formatted message on entry fill, exit signal and stop hit.

The whole subsystem is inert when \`TELEGRAM_BOT_TOKEN\` is unset, so this PR is a no-op in tests, CI and deployments without a bot configured.

### Highlights

- **One shared bot, per-user traceability**: each user links their own chat via a one-time deep-link + \`/start <token>\` webhook flow.
- **Per-alert toggle**: \`signal_configs.telegram_enabled\` lets the user pick exactly which configs go to Telegram.
- **Unified dispatch**: \`backend/notifications.py::notify_event\` is the single entry point; \`live_tracker\` calls it at 4 sites (fill, intrabar stop, candle exit, candle stop). Dedup via \`notification_log (event_type, reference_type, reference_id, channel)\`.
- **Reserved \`stop_moved\` event**: formatter and dedup ready for the trailing-stop work tracked in the related issue. No call-site added yet.
- **Schema parity**: new Alembic revision \`003_telegram_notifications\` matches inline SQLite migrations in \`database.py\`. PostgreSQL deploys pick up migrations automatically in the lifespan, as today.

### New env vars

| Variable | Purpose |
|---|---|
| \`TELEGRAM_BOT_TOKEN\` | Bot API token. Empty = subsystem no-op. |
| \`TELEGRAM_BOT_USERNAME\` | Builds the \`https://t.me/<bot>?start=<token>\` deep-link. |
| \`TELEGRAM_WEBHOOK_SECRET\` | Path secret + \`X-Telegram-Bot-Api-Secret-Token\` header. |
| \`TELEGRAM_WEBHOOK_URL\` | Optional; if set, \`setWebhook\` is called once at startup. |
| \`PUBLIC_BASE_URL\` | Used to build \"Ver trade\" links in outbound messages. |

### Related issue

Trailing stop work is tracked separately. This PR leaves the notification side ready: \`notifications._format_stop_moved\` already exists; the trailing-stop PR just needs to call \`notify_event(event_type=\"stop_moved\", ...)\` from wherever the stop is updated.

## Test plan

- [x] \`pytest tests/\` → 168 passed (21 new tests covering escaping, dispatch filtering, dedup, webhook secret validation, \`/start <token>\` flow, expired tokens).
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] End-to-end manual check in local with a real bot token:
  - [ ] \`POST /api/profile/telegram/link-token\` returns a deep-link.
  - [ ] \`/start <token>\` on the bot links the chat; UI reflects it within 3s.
  - [ ] A simulated entry fill (with toggle on + chat linked) delivers the Telegram message.
  - [ ] Disabling the toggle stops new messages; the internal \`notification_log\` keeps recording.
  - [ ] Re-processing the same event does not double-send.
- [x] CI green (lint + test + build).