### PR TITLE
feat(live): honor modo_ejecucion in pending entry fill (step 1 of #32)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Outbound alerts flow through a single entry point — `notifications.notify_even
 
 - **Sim-trade lifecycle**: `pending_entry` → `open` → `closed`. On close, `exit_reason` ∈ `{stop_intrabar, stop_candle, exit_signal, manual, config_deleted}`.
 - **Stop levels**: `stop_base` is the strategy's raw stop. `stop_trigger = stop_base × (1 − stop_cross_pct)` for longs, `× (1 + stop_cross_pct)` for shorts. Both the intrabar ticker check and the candle-close strategy state use `stop_trigger` so the two paths fire at the same price.
+- **Entry fill semantics (`modo_ejecucion`)**: `_fill_pending_entries` mirrors backtest. `open_next` (default): entry price is the open of the candle after the trigger and `entry_time = trigger_candle_time + step_ms`. `close_current`: entry price is the close of the trigger candle itself and `entry_time = trigger_candle_time`. Unknown/missing values fall back to `open_next` so legacy configs keep working.
 
 ## Key Environment Variables
 

--- a/backend/live_tracker.py
+++ b/backend/live_tracker.py
@@ -71,15 +71,19 @@ def _get_poll_interval(config: dict) -> int:
 async def _fill_pending_entries() -> None:
     """Fill entry_price for SimTrades in pending_entry state.
 
-    The entry price is the Open of the candle that started AFTER the signal.
-    Once that candle opens, we take the first available price as a proxy.
+    Honours ``modo_ejecucion`` from the strategy params:
+      * ``open_next`` (default): entry fills at the Open of the candle that
+        started AFTER the signal; ``entry_time = trigger_candle_time + step_ms``.
+      * ``close_current``: entry fills at the Close of the trigger candle
+        itself (already in DB when signal_engine created the sim_trade);
+        ``entry_time = trigger_candle_time``. Mirrors ``backtest_engine``.
     """
     async with get_db() as db:
         cursor = await db.execute(
             """SELECT st.id, st.symbol, st.interval, st.side, st.signal_id,
                       st.invested_amount, st.portfolio, st.leverage,
                       st.stop_base, st.stop_trigger, st.config_id,
-                      s.trigger_candle_time, sc.cost_bps, sc.strategy
+                      s.trigger_candle_time, sc.cost_bps, sc.strategy, sc.params
                FROM sim_trades st
                JOIN signals s ON st.signal_id = s.id
                JOIN signal_configs sc ON st.config_id = sc.id
@@ -101,6 +105,19 @@ async def _fill_pending_entries() -> None:
         trigger_time = trade["trigger_candle_time"]
         next_candle_open = trigger_time + step_ms
 
+        try:
+            params = json.loads(trade["params"]) if trade.get("params") else {}
+        except (TypeError, json.JSONDecodeError):
+            params = {}
+        execution_mode = params.get("modo_ejecucion", "open_next")
+        if execution_mode not in ("open_next", "close_current"):
+            logger.warning(
+                "SimTrade %d: unknown modo_ejecucion=%r, falling back to open_next",
+                trade["id"],
+                execution_mode,
+            )
+            execution_mode = "open_next"
+
         # Trigger async sync for the entry candle range if missing
         # (only the 2-candle window around the trigger; full history is handled by scanner)
         await ensure_candles(
@@ -110,29 +127,50 @@ async def _fill_pending_entries() -> None:
             next_candle_open + step_ms,
         )
 
-        # Check if next candle exists in DB (means it has opened and we have data)
-        async with get_db() as db:
-            cursor = await db.execute(
-                "SELECT open FROM klines WHERE symbol = ? AND interval = ? AND open_time = ?",
-                (trade["symbol"], interval, next_candle_open),
-            )
-            row = await cursor.fetchone()
-
         entry_price: float | None = None
-        if row is not None:
+        entry_time: int
+
+        if execution_mode == "close_current":
+            # Fill at trigger candle's close — always in DB because signal_engine
+            # read it to generate the signal.
+            async with get_db() as db:
+                cursor = await db.execute(
+                    "SELECT close FROM klines WHERE symbol = ? AND interval = ? AND open_time = ?",
+                    (trade["symbol"], interval, trigger_time),
+                )
+                row = await cursor.fetchone()
+            if row is None:
+                logger.warning(
+                    "SimTrade %d: trigger candle %d missing in klines for %s %s — retrying next cycle",
+                    trade["id"],
+                    trigger_time,
+                    trade["symbol"],
+                    interval,
+                )
+                continue
             entry_price = float(row[0])
+            entry_time = trigger_time
         else:
-            # If the next candle hasn't appeared in DB yet, check if we're past
-            # its open time — if so, use current ticker as proxy
-            if _now_ms() >= next_candle_open + 5000:  # 5s grace
+            # open_next: wait for the next candle to open and fill at its open.
+            async with get_db() as db:
+                cursor = await db.execute(
+                    "SELECT open FROM klines WHERE symbol = ? AND interval = ? AND open_time = ?",
+                    (trade["symbol"], interval, next_candle_open),
+                )
+                row = await cursor.fetchone()
+
+            if row is not None:
+                entry_price = float(row[0])
+            elif _now_ms() >= next_candle_open + 5000:  # 5s grace
                 try:
                     entry_price = await binance_client.get_ticker_price(trade["symbol"])
                 except Exception as exc:
                     logger.warning("Could not get ticker for pending entry fill: %s", exc)
                     continue
 
-        if entry_price is None:
-            continue  # not time yet
+            if entry_price is None:
+                continue  # not time yet
+            entry_time = next_candle_open
 
         invested = float(trade["invested_amount"])
         cost_bps = float(trade["cost_bps"])
@@ -147,7 +185,7 @@ async def _fill_pending_entries() -> None:
                    SET entry_price = ?, entry_time = ?, quantity = ?, fees = ?,
                        equity_peak = ?, status = 'open', updated_at = ?
                    WHERE id = ?""",
-                (entry_price, next_candle_open, quantity, fee, float(trade["portfolio"]), now, trade["id"]),
+                (entry_price, entry_time, quantity, fee, float(trade["portfolio"]), now, trade["id"]),
             )
             await db.execute(
                 "UPDATE signals SET status = 'active' WHERE id = ?",

--- a/tests/test_live_integration.py
+++ b/tests/test_live_integration.py
@@ -476,6 +476,204 @@ class TestEntryFill:
         assert trades[0]["status"] == "pending_entry"
         assert trades[0]["entry_price"] is None
 
+    @pytest.mark.asyncio
+    async def test_close_current_fills_at_trigger_candle_close(self):
+        """modo_ejecucion=close_current fills at the Close of the trigger candle itself."""
+        trigger_time = BASE_TIME
+        trigger_close = 123.5
+        next_open = 200.0  # much higher — asserts we did NOT use it
+
+        await _setup_db()
+        config = await _insert_config(
+            params=json.dumps(
+                {
+                    "N_entrada": 5,
+                    "M_salida": 3,
+                    "stop_pct": 0.02,
+                    "salida_por_ruptura": True,
+                    "modo_ejecucion": "close_current",
+                },
+                sort_keys=True,
+            )
+        )
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'pending', ?)""",
+                (config["id"], trigger_time, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'pending_entry',
+                           10000.0, 10000.0, 1.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], now, now),
+            )
+            await db.commit()
+
+        # Insert the trigger candle (with a distinct close) AND the next candle
+        # (with a wildly different open) — the fill must pick the trigger close.
+        await _insert_kline(
+            {
+                "open_time": trigger_time,
+                "open": 100.0,
+                "high": 130.0,
+                "low": 99.0,
+                "close": trigger_close,
+                "volume": 1000.0,
+            }
+        )
+        await _insert_kline(
+            {
+                "open_time": trigger_time + STEP_MS,
+                "open": next_open,
+                "high": 205.0,
+                "low": 199.0,
+                "close": 203.0,
+                "volume": 1000.0,
+            }
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        trades = await _get_sim_trades(status="open")
+        assert len(trades) == 1
+        assert trades[0]["entry_price"] == pytest.approx(trigger_close)
+        assert trades[0]["entry_time"] == trigger_time  # NOT next_candle_open
+        assert trades[0]["quantity"] == pytest.approx(10000.0 / trigger_close)
+
+    @pytest.mark.asyncio
+    async def test_explicit_open_next_fills_at_next_candle_open(self):
+        """modo_ejecucion=open_next (explicit) keeps the historical fill-at-next-open behaviour."""
+        trigger_time = BASE_TIME
+        trigger_close = 123.5
+        next_open = 127.0
+
+        await _setup_db()
+        config = await _insert_config(
+            params=json.dumps(
+                {
+                    "N_entrada": 5,
+                    "M_salida": 3,
+                    "stop_pct": 0.02,
+                    "salida_por_ruptura": True,
+                    "modo_ejecucion": "open_next",
+                },
+                sort_keys=True,
+            )
+        )
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'pending', ?)""",
+                (config["id"], trigger_time, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'pending_entry',
+                           10000.0, 10000.0, 1.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], now, now),
+            )
+            await db.commit()
+
+        await _insert_kline(
+            {
+                "open_time": trigger_time,
+                "open": 100.0,
+                "high": 130.0,
+                "low": 99.0,
+                "close": trigger_close,
+                "volume": 1000.0,
+            }
+        )
+        await _insert_kline(
+            {
+                "open_time": trigger_time + STEP_MS,
+                "open": next_open,
+                "high": 130.0,
+                "low": 125.0,
+                "close": 128.0,
+                "volume": 1000.0,
+            }
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        trades = await _get_sim_trades(status="open")
+        assert len(trades) == 1
+        assert trades[0]["entry_price"] == pytest.approx(next_open)
+        assert trades[0]["entry_time"] == trigger_time + STEP_MS
+
+    @pytest.mark.asyncio
+    async def test_missing_modo_ejecucion_defaults_to_open_next(self):
+        """Legacy configs without modo_ejecucion in params continue to fill at next open."""
+        trigger_time = BASE_TIME
+        next_open = 127.0
+
+        await _setup_db()
+        # Default _insert_config omits modo_ejecucion — mirrors old configs.
+        config = await _insert_config()
+
+        now = _now_iso()
+        async with get_db() as db:
+            cursor = await db.execute(
+                """INSERT INTO signals
+                    (config_id, symbol, interval, strategy, side,
+                     trigger_candle_time, stop_price, stop_trigger_price,
+                     status, created_at)
+                   VALUES (?, 'BTCUSDT', '1h', 'breakout', 'long', ?, 96.04, 94.12, 'pending', ?)""",
+                (config["id"], trigger_time, now),
+            )
+            sig_id = cursor.lastrowid
+            await db.execute(
+                """INSERT INTO sim_trades
+                    (signal_id, config_id, symbol, interval, side,
+                     stop_base, stop_trigger, status, portfolio, invested_amount,
+                     leverage, fees, created_at, updated_at)
+                   VALUES (?, ?, 'BTCUSDT', '1h', 'long', 96.04, 94.12, 'pending_entry',
+                           10000.0, 10000.0, 1.0, 0.0, ?, ?)""",
+                (sig_id, config["id"], now, now),
+            )
+            await db.commit()
+
+        await _insert_kline(
+            {
+                "open_time": trigger_time + STEP_MS,
+                "open": next_open,
+                "high": 130.0,
+                "low": 125.0,
+                "close": 128.0,
+                "volume": 1000.0,
+            }
+        )
+
+        with patch("backend.live_tracker.ensure_candles", new=AsyncMock(return_value=True)):
+            await _fill_pending_entries()
+
+        trades = await _get_sim_trades(status="open")
+        assert len(trades) == 1
+        assert trades[0]["entry_price"] == pytest.approx(next_open)
+        assert trades[0]["entry_time"] == trigger_time + STEP_MS
+
 
 # ---------------------------------------------------------------------------
 # Tests: candle-close exit (_check_candle_close_exits)


### PR DESCRIPTION
## Summary

- `backend/live_tracker.py::_fill_pending_entries` now reads `modo_ejecucion` from `signal_configs.params` and branches accordingly:
  - **`close_current`**: fills at the close of the trigger candle (already in DB from `signal_engine`), `entry_time = trigger_candle_time` — mirrors `backtest_engine`.
  - **`open_next`** (default, and fallback for unknown/missing values): unchanged historical behavior (fill at next candle open, `entry_time = trigger + step_ms`).
- 3 new tests in `tests/test_live_integration.py::TestEntryFill` cover: `close_current` fill, explicit `open_next` regression, and missing-field legacy default.
- `CLAUDE.md` → new line under *Live-mode invariants* describing the two fill branches.

Closes step 1 of #32. `equity_peak` (step 2) is intentionally left untouched because it's the data prerequisite for the trailing-stop work tracked in #36.

## Test plan

- [x] `pytest -q` — 171 tests pass locally.
- [x] `ruff check backend/ tests/` — all checks passed.
- [x] `ruff format --check backend/ tests/` — 37 files already formatted.
- [ ] Manual smoke in dev: create a signal_config with `modo_ejecucion=close_current`, wait for a `pending_entry`, confirm `_fill_pending_entries` fills at the trigger close in the same cycle.
- [ ] Repeat with `modo_ejecucion=open_next` and confirm fill still waits for the next candle's open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)