### PR TITLE
feat(trailing-stop): motor, estrategias y evento stop_moved (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,11 +62,13 @@ DATABASE_URL=postgresql://... alembic upgrade head
 | `backtest_metrics.py` | Computes performance stats (Sharpe, drawdown, win-rate, etc.) from a trade log |
 | `signal_engine.py` | Background loop: polls active `signal_configs`, calls `ensure_candles`, runs `strategy.on_candle()`, persists signals, spawns sim trades |
 | `live_tracker.py` | Background loop: updates open `sim_trades` (entry fills, stop-outs, exits) from live Binance ticker price; emits user-facing notifications via `notifications.notify_event` |
-| `notifications.py` | Unified dispatcher for user-facing trade events. Resolves the recipient from `signal_configs.user_id`, honours the per-config `telegram_enabled` toggle, dedupes through `notification_log (event_type, reference_type, reference_id, channel)` and sends Telegram when all gates pass. Supported event types: `entry`, `exit_signal`, `stop_hit`, `stop_moved` (reserved for trailing-stop feature — see corresponding GitHub issue) |
+| `notifications.py` | Unified dispatcher for user-facing trade events. Resolves the recipient from `signal_configs.user_id`, honours the per-config `telegram_enabled` toggle, dedupes through `notification_log (event_type, reference_type, reference_id, channel)` and sends Telegram when all gates pass. Supported event types: `entry`, `exit_signal`, `stop_hit`, `stop_moved`. Note that `stop_moved` uses `reference_type="sim_trade_stop_move"` + `reference_id=sim_trade_stop_moves.id` so each trailing move is a distinct dedup key (many moves per trade are expected) |
 | `telegram_client.py` | Thin async Telegram Bot API client (`send_message`, `set_webhook`, MarkdownV2 `escape_md`). No-op when `TELEGRAM_BOT_TOKEN` is unset — safe default for tests and CI |
 | `strategies/base.py` | `Strategy` ABC: defines `get_parameters()`, `init()`, `on_candle()` interface shared by all strategies |
 | `strategies/breakout.py` | Breakout strategy implementation |
+| `strategies/breakout_trailing.py` | Breakout variant that inherits from `BreakoutStrategy` and emits `move_stop` using a rolling Min/Max trailing reference |
 | `strategies/support_resistance.py` | Support/resistance strategy implementation |
+| `strategies/support_resistance_trailing.py` | Support/resistance variant that inherits from `SupportResistanceStrategy` and emits `move_stop` from the latest confirmed zigzag level |
 | `api/data_routes.py` | `/api/pairs`, `/api/download`, `/api/candles`, `/api/metrics`, ... |
 | `api/backtest_routes.py` | `/api/strategies`, `/api/backtest` |
 | `api/signal_routes.py` | `/api/signals`, `/api/sim-trades`, `/api/real-trades`. `signal_configs` payloads accept `telegram_enabled` on create/patch |
@@ -92,7 +94,7 @@ Two modes selected by the `DATABASE_URL` env var:
 - **SQLite (default/dev):** schema created inline by `init_db()`, file at `data/trading_tools.db`. Additive migrations use `PRAGMA table_info` + `ALTER TABLE` guards.
 - **PostgreSQL (prod):** Alembic runs automatically at startup. Migrations in `alembic/versions/`.
 
-Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_configs`, `signals`, `sim_trades`, `real_trades`, `notification_log`, `telegram_link_tokens`.
+Core tables: `klines`, `download_jobs`, `derived_metrics`, `users`, `signal_configs`, `signals`, `sim_trades`, `sim_trade_stop_moves`, `real_trades`, `notification_log`, `telegram_link_tokens`.
 
 Keep the inline SQLite migration in `init_db()` and the Alembic revision in lockstep — both must produce the same final schema. Any new column/table lands in both or neither.
 
@@ -108,11 +110,12 @@ One shared bot per deployment. Each user links their own chat on first use:
 2. User opens the link and sends `/start <token>` to the bot.
 3. Telegram POSTs the update to `/api/telegram/webhook/{secret}`; the webhook consumes the token and stores `telegram_chat_id` / `telegram_username` on the user row.
 
-Outbound alerts flow through a single entry point — `notifications.notify_event` — which live_tracker calls at four sites (entry fill, exit signal, intrabar stop, candle-close stop). The dispatcher filters by the per-config `telegram_enabled` toggle + the user's linked chat, and dedupes on `notification_log (event_type, reference_type, reference_id, channel)`. The whole subsystem is inert (no HTTP, no reply) whenever `TELEGRAM_BOT_TOKEN` is empty — this is the invariant that keeps tests and CI green without mocking the network.
+Outbound alerts flow through a single entry point — `notifications.notify_event` — which live_tracker calls at five sites (entry fill, exit signal, intrabar stop, candle-close stop, trailing stop move). The dispatcher filters by the per-config `telegram_enabled` toggle + the user's linked chat, and dedupes on `notification_log (event_type, reference_type, reference_id, channel)`. The whole subsystem is inert (no HTTP, no reply) whenever `TELEGRAM_BOT_TOKEN` is empty — this is the invariant that keeps tests and CI green without mocking the network.
 ### Live-mode invariants
 
 - **Sim-trade lifecycle**: `pending_entry` → `open` → `closed`. On close, `exit_reason` ∈ `{stop_intrabar, stop_candle, exit_signal, manual, config_deleted}`.
 - **Stop levels**: `stop_base` is the strategy's raw stop. `stop_trigger = stop_base × (1 − stop_cross_pct)` for longs, `× (1 + stop_cross_pct)` for shorts. Both the intrabar ticker check and the candle-close strategy state use `stop_trigger` so the two paths fire at the same price.
+- **Trailing stop (`move_stop`)**: strategies may emit `Signal(action="move_stop", stop_price=<new_base>)`. `live_tracker._apply_stop_moves` accepts the move only if it *tightens* the stop (long: new base > current; short: new base < current); loosening moves are logged and ignored. On accept, `stop_base` and `stop_trigger` on `sim_trades` are updated together using the same `stop_cross_pct` formula as at entry, and a row is appended to `sim_trade_stop_moves` for audit. The `notify_event(event_type="stop_moved", ...)` call uses `reference_type="sim_trade_stop_move"` + `reference_id=sim_trade_stop_moves.id` so multiple moves per trade don't collide on the dedup index. In the backtest loop, `move_stop` simply updates `state.stop_price` — no history row (the trade_log still captures the eventual exit).
 - **Entry fill semantics (`modo_ejecucion`)**: `_fill_pending_entries` mirrors backtest. `open_next` (default): entry price is the open of the candle after the trigger and `entry_time = trigger_candle_time + step_ms`. `close_current`: entry price is the close of the trigger candle itself and `entry_time = trigger_candle_time`. Unknown/missing values fall back to `open_next` so legacy configs keep working.
 
 ## Key Environment Variables

--- a/alembic/versions/004_trailing_stop.py
+++ b/alembic/versions/004_trailing_stop.py
@@ -1,0 +1,47 @@
+"""Trailing stop: audit trail for stop movements
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-24
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sim_trade_stop_moves",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column(
+            "sim_trade_id",
+            sa.Integer,
+            sa.ForeignKey("sim_trades.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("prev_stop_base", sa.Float, nullable=False),
+        sa.Column("new_stop_base", sa.Float, nullable=False),
+        sa.Column("prev_stop_trigger", sa.Float, nullable=False),
+        sa.Column("new_stop_trigger", sa.Float, nullable=False),
+        sa.Column("candle_time", sa.BigInteger, nullable=False),
+        sa.Column("created_at", sa.Text, nullable=False),
+    )
+    op.create_index(
+        "idx_sim_trade_stop_moves_trade",
+        "sim_trade_stop_moves",
+        ["sim_trade_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_sim_trade_stop_moves_trade", table_name="sim_trade_stop_moves")
+    op.drop_table("sim_trade_stop_moves")

--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -409,6 +409,35 @@ async def get_sim_trade(
     return dict(zip(cols, row, strict=False))
 
 
+@router.get("/sim-trades/{trade_id}/stop-moves")
+async def list_sim_trade_stop_moves(
+    trade_id: int,
+    user: AuthUser = Depends(get_current_user),
+) -> dict:
+    """Return the trailing-stop movement history of a single SimTrade."""
+    async with get_db() as db:
+        cursor = await db.execute(
+            """SELECT st.id FROM sim_trades st
+               JOIN signal_configs sc ON st.config_id = sc.id
+               WHERE st.id = ? AND sc.user_id = ?""",
+            (trade_id, user.id),
+        )
+        if await cursor.fetchone() is None:
+            raise HTTPException(404, f"SimTrade {trade_id} not found")
+
+        cursor = await db.execute(
+            """SELECT id, sim_trade_id, prev_stop_base, new_stop_base,
+                      prev_stop_trigger, new_stop_trigger, candle_time, created_at
+               FROM sim_trade_stop_moves
+               WHERE sim_trade_id = ?
+               ORDER BY id ASC""",
+            (trade_id,),
+        )
+        rows = await cursor.fetchall()
+        cols = [d[0] for d in cursor.description]
+    return {"stop_moves": [dict(zip(cols, row, strict=False)) for row in rows]}
+
+
 @router.post("/sim-trades/{trade_id}/close")
 async def close_sim_trade(
     trade_id: int,

--- a/backend/backtest_engine.py
+++ b/backend/backtest_engine.py
@@ -105,6 +105,16 @@ async def run_backtest(
         # Get signals from strategy
         signals = strategy.on_candle(t, candle, state)
 
+        # Apply stop-moves first so a same-candle exit uses the updated stop.
+        for sig in signals:
+            if sig.action != "move_stop" or state.side == "flat" or sig.stop_price <= 0:
+                continue
+            tightens = (state.side == "long" and sig.stop_price > state.stop_price) or (
+                state.side == "short" and sig.stop_price < state.stop_price
+            )
+            if tightens:
+                state.stop_price = sig.stop_price
+
         exit_executed = False
         for sig in signals:
             if sig.action in ("stop_long", "stop_short", "exit_long", "exit_short") and state.side != "flat":

--- a/backend/database.py
+++ b/backend/database.py
@@ -381,6 +381,19 @@ async def init_db() -> None:
             );
             CREATE INDEX IF NOT EXISTS idx_telegram_link_tokens_user
                 ON telegram_link_tokens (user_id);
+
+            CREATE TABLE IF NOT EXISTS sim_trade_stop_moves (
+                id                 INTEGER PRIMARY KEY,
+                sim_trade_id       INTEGER NOT NULL REFERENCES sim_trades(id) ON DELETE CASCADE,
+                prev_stop_base     REAL    NOT NULL,
+                new_stop_base      REAL    NOT NULL,
+                prev_stop_trigger  REAL    NOT NULL,
+                new_stop_trigger   REAL    NOT NULL,
+                candle_time        INTEGER NOT NULL,
+                created_at         TEXT    NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_sim_trade_stop_moves_trade
+                ON sim_trade_stop_moves (sim_trade_id);
         """)
         await db.commit()
 

--- a/backend/live_tracker.py
+++ b/backend/live_tracker.py
@@ -344,6 +344,118 @@ async def _check_intrabar_stops() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Stop-move handling (trailing stop)
+# ---------------------------------------------------------------------------
+
+
+async def _apply_stop_moves(
+    trade: dict,
+    signals: list,
+    candle_open_time: int,
+    state: PositionState,
+) -> None:
+    """Apply every ``move_stop`` signal against the open trade.
+
+    For each accepted move: tighten stop_base/stop_trigger on sim_trades, append a
+    row to sim_trade_stop_moves, mirror it onto ``state`` so later exit checks in
+    the same candle see the updated value, and emit a notify_event.
+
+    Rejects any move that would loosen the stop (long: new <= current base;
+    short: new >= current base). Honours stop_cross_pct buffer — same formula as
+    at entry fill, so the intrabar poller and candle-close strategy view stay
+    aligned.
+    """
+    # Collect only tightening move_stop signals with a positive level.
+    moves = [s for s in signals if getattr(s, "action", None) == "move_stop" and s.stop_price > 0]
+    if not moves:
+        return
+
+    side = trade["side"]
+    stop_cross_pct = float(trade.get("stop_cross_pct") or 0.0)
+    buffer_sign = -1.0 if side == "long" else 1.0
+
+    now = _now_iso()
+    for sig in moves:
+        prev_base = float(trade["stop_base"])
+        prev_trigger = float(trade["stop_trigger"])
+        new_base = float(sig.stop_price)
+
+        tightens = (side == "long" and new_base > prev_base) or (side == "short" and new_base < prev_base)
+        if not tightens:
+            logger.warning(
+                "SimTrade %d move_stop ignored (loosens stop): side=%s prev=%.6f new=%.6f",
+                trade["id"],
+                side,
+                prev_base,
+                new_base,
+            )
+            continue
+
+        new_trigger = new_base * (1.0 + buffer_sign * stop_cross_pct)
+
+        async with get_db() as db:
+            await db.execute(
+                """UPDATE sim_trades
+                   SET stop_base = ?, stop_trigger = ?, updated_at = ?
+                   WHERE id = ?""",
+                (new_base, new_trigger, now, trade["id"]),
+            )
+            cursor = await db.execute(
+                """INSERT INTO sim_trade_stop_moves
+                       (sim_trade_id, prev_stop_base, new_stop_base,
+                        prev_stop_trigger, new_stop_trigger, candle_time, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    trade["id"],
+                    prev_base,
+                    new_base,
+                    prev_trigger,
+                    new_trigger,
+                    candle_open_time,
+                    now,
+                ),
+            )
+            move_id = cursor.lastrowid
+            await db.commit()
+
+        # Mirror onto in-memory trade + PositionState so subsequent signals align.
+        trade["stop_base"] = new_base
+        trade["stop_trigger"] = new_trigger
+        state.stop_price = new_trigger
+
+        entry_price = float(trade["entry_price"]) if trade.get("entry_price") else 0.0
+        locked_pct: float | None = None
+        if entry_price > 0:
+            raw = (new_base - entry_price) / entry_price
+            locked_pct = raw if side == "long" else -raw
+
+        await notify_event(
+            event_type="stop_moved",
+            config_id=trade["config_id"],
+            reference_type="sim_trade_stop_move",
+            reference_id=int(move_id) if move_id is not None else trade["id"],
+            payload={
+                "symbol": trade["symbol"],
+                "interval": trade["interval"],
+                "side": side,
+                "prev_stop": prev_base,
+                "new_stop": new_base,
+                "locked_pct": locked_pct,
+                "sim_trade_id": trade["id"],
+            },
+        )
+
+        logger.info(
+            "SimTrade %d STOP MOVED: side=%s %.6f -> %.6f (trigger %.6f)",
+            trade["id"],
+            side,
+            prev_base,
+            new_base,
+            new_trigger,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Candle-close exit check
 # ---------------------------------------------------------------------------
 
@@ -438,6 +550,9 @@ async def _check_candle_close_exits(interval: str | None = None) -> None:
             )
 
             signals = strategy.on_candle(t_last, candle, state)
+
+            # Apply stop-moves first so a same-candle exit uses the updated stop.
+            await _apply_stop_moves(trade, signals, int(candle["open_time"]), state)
 
             for sig in signals:
                 if sig.action in ("exit_long", "exit_short"):

--- a/backend/strategies/__init__.py
+++ b/backend/strategies/__init__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from backend.strategies.base import Strategy
 from backend.strategies.breakout import BreakoutStrategy
+from backend.strategies.breakout_trailing import BreakoutTrailingStrategy
 from backend.strategies.support_resistance import SupportResistanceStrategy
+from backend.strategies.support_resistance_trailing import SupportResistanceTrailingStrategy
 
 _REGISTRY: dict[str, type[Strategy]] = {}
 
@@ -14,7 +16,9 @@ def _register(cls: type[Strategy]) -> None:
 
 
 _register(BreakoutStrategy)
+_register(BreakoutTrailingStrategy)
 _register(SupportResistanceStrategy)
+_register(SupportResistanceTrailingStrategy)
 
 
 def get_strategy(name: str) -> Strategy:

--- a/backend/strategies/base.py
+++ b/backend/strategies/base.py
@@ -30,9 +30,9 @@ class PositionState:
 
 @dataclass
 class Signal:
-    action: Literal["entry_long", "entry_short", "exit_long", "exit_short", "stop_long", "stop_short"]
+    action: Literal["entry_long", "entry_short", "exit_long", "exit_short", "stop_long", "stop_short", "move_stop"]
     price: float = 0.0  # suggested execution price (0 = use next open)
-    stop_price: float = 0.0
+    stop_price: float = 0.0  # for entry_*: initial stop; for move_stop: new raw stop level
 
 
 class Strategy(ABC):

--- a/backend/strategies/breakout_trailing.py
+++ b/backend/strategies/breakout_trailing.py
@@ -1,0 +1,74 @@
+"""Breakout with trailing stop.
+
+Inherits the entry/exit/initial-stop logic of BreakoutStrategy. Adds an extra
+``move_stop`` signal that trails behind price using the rolling extreme of the
+last ``trailing_lookback`` closed candles (Min for longs, Max for shorts),
+with the same ``stop_pct`` buffer that the base strategy applies at entry.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backend.strategies.base import ParameterDef, PositionState, Signal
+from backend.strategies.breakout import BreakoutStrategy
+
+
+class BreakoutTrailingStrategy(BreakoutStrategy):
+    name = "breakout_trailing"
+    description = (
+        "Breakout con trailing stop. Hereda entradas/salidas de 'breakout'; "
+        "mueve el stop detrás del precio usando el Min/Max de las últimas "
+        "trailing_lookback velas cerradas (con el buffer stop_pct)."
+    )
+
+    def get_parameters(self) -> list[ParameterDef]:
+        params = super().get_parameters()
+        params.append(
+            ParameterDef(
+                "trailing_lookback",
+                "int",
+                10,
+                1,
+                500,
+                "Lookback (in closed candles) for the trailing Min/Max reference level",
+            )
+        )
+        return params
+
+    def init(self, params: dict, candles: pd.DataFrame) -> None:
+        super().init(params, candles)
+        lookback = int(params.get("trailing_lookback", 10))
+        # Rolling extremes over the last `lookback` closed candles (exclusive of t).
+        self.trail_min = candles["low"].shift(1).rolling(lookback).min()
+        self.trail_max = candles["high"].shift(1).rolling(lookback).max()
+
+    def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
+        signals = super().on_candle(t, candle, state)
+
+        # Base class returns early on stop/exit; no trailing in that case.
+        # Only emit move_stop when a position is open and base didn't close it.
+        if state.side == "flat" or any(
+            s.action in ("stop_long", "stop_short", "exit_long", "exit_short") for s in signals
+        ):
+            return signals
+
+        stop_pct = float(self.params.get("stop_pct", 0.02))
+
+        if state.side == "long":
+            ref = self.trail_min.iloc[t]
+            if pd.isna(ref):
+                return signals
+            candidate = float(ref) * (1.0 - stop_pct)
+            if candidate > state.stop_price:
+                signals.append(Signal(action="move_stop", stop_price=candidate))
+
+        elif state.side == "short":
+            ref = self.trail_max.iloc[t]
+            if pd.isna(ref):
+                return signals
+            candidate = float(ref) * (1.0 + stop_pct)
+            if candidate < state.stop_price:
+                signals.append(Signal(action="move_stop", stop_price=candidate))
+
+        return signals

--- a/backend/strategies/support_resistance_trailing.py
+++ b/backend/strategies/support_resistance_trailing.py
@@ -1,0 +1,49 @@
+"""Support/Resistance with trailing stop.
+
+Inherits the zigzag-based entries/exits of SupportResistanceStrategy. While a
+position is open, emits a ``move_stop`` signal whenever a newly confirmed
+support (long) or resistance (short) yields a tighter stop than the current
+one, applying the same ``stop_pct`` buffer the base strategy uses at entry.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from backend.strategies.base import PositionState, Signal
+from backend.strategies.support_resistance import SupportResistanceStrategy
+
+
+class SupportResistanceTrailingStrategy(SupportResistanceStrategy):
+    name = "support_resistance_trailing"
+    description = (
+        "Soportes/Resistencias con trailing stop. Hereda entradas/salidas de "
+        "'support_resistance'; cada vez que se confirma un nuevo soporte (long) "
+        "o resistencia (short) más cercano al precio, mueve el stop al nivel "
+        "soporte/resistencia × (1 ∓ stop_pct)."
+    )
+
+    def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
+        signals = super().on_candle(t, candle, state)
+
+        if state.side == "flat" or any(
+            s.action in ("stop_long", "stop_short", "exit_long", "exit_short") for s in signals
+        ):
+            return signals
+
+        stop_pct = float(self.params.get("stop_pct", 0.02))
+        support = self.last_support[t]
+        resistance = self.last_resistance[t]
+
+        if state.side == "long" and not np.isnan(support):
+            candidate = float(support) * (1.0 - stop_pct)
+            if candidate > state.stop_price:
+                signals.append(Signal(action="move_stop", stop_price=candidate))
+
+        elif state.side == "short" and not np.isnan(resistance):
+            candidate = float(resistance) * (1.0 + stop_pct)
+            if candidate < state.stop_price:
+                signals.append(Signal(action="move_stop", stop_price=candidate))
+
+        return signals

--- a/frontend/src/components/SignalsPanel.jsx
+++ b/frontend/src/components/SignalsPanel.jsx
@@ -470,6 +470,33 @@ function SignalsList({ signals }) {
 
 /* ---- SimTrades table ---- */
 function SimTradesList({ trades, onClose }) {
+  const [expandedId, setExpandedId] = useState(null)
+  const [movesByTrade, setMovesByTrade] = useState({})
+  const [loadingMoves, setLoadingMoves] = useState(false)
+
+  const toggleExpand = useCallback(async (tradeId) => {
+    if (expandedId === tradeId) {
+      setExpandedId(null)
+      return
+    }
+    setExpandedId(tradeId)
+    if (movesByTrade[tradeId] !== undefined) return
+    setLoadingMoves(true)
+    try {
+      const res = await apiFetch(`/api/sim-trades/${tradeId}/stop-moves`)
+      if (res.ok) {
+        const data = await res.json()
+        setMovesByTrade(prev => ({ ...prev, [tradeId]: data.stop_moves ?? [] }))
+      } else {
+        setMovesByTrade(prev => ({ ...prev, [tradeId]: [] }))
+      }
+    } catch {
+      setMovesByTrade(prev => ({ ...prev, [tradeId]: [] }))
+    } finally {
+      setLoadingMoves(false)
+    }
+  }, [expandedId, movesByTrade])
+
   if (!trades || trades.length === 0) {
     return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem', padding: 'var(--space-3)' }}>No sim trades yet.</div>
   }
@@ -478,6 +505,7 @@ function SimTradesList({ trades, onClose }) {
       <table className="trade-table">
         <thead>
           <tr>
+            <th style={{ width: '2rem' }}></th>
             <th className="ta-right">ID</th>
             <th>Config</th>
             <th>Symbol</th>
@@ -495,31 +523,91 @@ function SimTradesList({ trades, onClose }) {
         <tbody>
           {trades.map(t => {
             const pnlColor = t.pnl > 0 ? 'var(--color-success)' : t.pnl < 0 ? 'var(--color-danger)' : 'var(--text-secondary)'
+            const isExpanded = expandedId === t.id
+            const moves = movesByTrade[t.id]
             return (
-              <tr key={t.id}>
-                <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
-                <td>
-                  <ConfigBadge configId={t.config_id} strategy={t.config_strategy} params={t.config_params} />
-                </td>
-                <td>{t.symbol}</td>
-                <td style={{ color: t.side === 'long' ? 'var(--color-success)' : 'var(--color-danger)', fontWeight: 600 }}>
-                  {t.side?.toUpperCase()}
-                </td>
-                <td className="ta-right num-col">{t.entry_price ? fmtNum(t.entry_price, 4) : '—'}</td>
-                <td className="ta-right num-col">{fmtNum(t.stop_trigger, 4)}</td>
-                <td className="ta-right num-col">{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
-                <td>{t.exit_reason || '—'}</td>
-                <td className="ta-right num-col" style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
-                <td className="ta-right num-col" style={{ color: pnlColor }}>{t.pnl_pct != null ? fmtNum(t.pnl_pct * 100, 2) + '%' : '—'}</td>
-                <td><StatusBadge status={t.status} /></td>
-                <td className="ta-center">
-                  {t.status === 'open' && (
-                    <button className="btn btn-sm btn-secondary" onClick={() => onClose(t.id)}>Close</button>
-                  )}
-                </td>
-              </tr>
+              <React.Fragment key={t.id}>
+                <tr>
+                  <td className="ta-center">
+                    <button
+                      type="button"
+                      onClick={() => toggleExpand(t.id)}
+                      title="Show stop-move history"
+                      style={{
+                        background: 'transparent', border: 'none', cursor: 'pointer',
+                        color: 'var(--text-muted)', padding: '0.25rem',
+                      }}
+                    >{isExpanded ? '▾' : '▸'}</button>
+                  </td>
+                  <td className="ta-right num-col" style={{ fontFamily: 'var(--font-mono)', fontSize: '0.8rem' }}>{t.id}</td>
+                  <td>
+                    <ConfigBadge configId={t.config_id} strategy={t.config_strategy} params={t.config_params} />
+                  </td>
+                  <td>{t.symbol}</td>
+                  <td style={{ color: t.side === 'long' ? 'var(--color-success)' : 'var(--color-danger)', fontWeight: 600 }}>
+                    {t.side?.toUpperCase()}
+                  </td>
+                  <td className="ta-right num-col">{t.entry_price ? fmtNum(t.entry_price, 4) : '—'}</td>
+                  <td className="ta-right num-col">{fmtNum(t.stop_trigger, 4)}</td>
+                  <td className="ta-right num-col">{t.exit_price ? fmtNum(t.exit_price, 4) : '—'}</td>
+                  <td>{t.exit_reason || '—'}</td>
+                  <td className="ta-right num-col" style={{ color: pnlColor, fontWeight: 600 }}>{t.pnl != null ? fmtMoney(t.pnl) : '—'}</td>
+                  <td className="ta-right num-col" style={{ color: pnlColor }}>{t.pnl_pct != null ? fmtNum(t.pnl_pct * 100, 2) + '%' : '—'}</td>
+                  <td><StatusBadge status={t.status} /></td>
+                  <td className="ta-center">
+                    {t.status === 'open' && (
+                      <button className="btn btn-sm btn-secondary" onClick={() => onClose(t.id)}>Close</button>
+                    )}
+                  </td>
+                </tr>
+                {isExpanded && (
+                  <tr>
+                    <td colSpan={13} style={{ background: 'var(--surface-1)', padding: 'var(--space-3)' }}>
+                      <StopMovesDetail moves={moves} loading={loadingMoves && moves === undefined} />
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
             )
           })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StopMovesDetail({ moves, loading }) {
+  if (loading) return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading stop moves…</div>
+  if (!moves || moves.length === 0) {
+    return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>No stop moves for this trade.</div>
+  }
+  return (
+    <div>
+      <div style={{ fontWeight: 600, marginBottom: 'var(--space-2)' }}>Stop moves ({moves.length})</div>
+      <table className="trade-table" style={{ fontSize: '0.8rem' }}>
+        <thead>
+          <tr>
+            <th className="ta-right">#</th>
+            <th className="ta-right">Prev base</th>
+            <th className="ta-right">New base</th>
+            <th className="ta-right">Prev trigger</th>
+            <th className="ta-right">New trigger</th>
+            <th className="ta-right">Candle time</th>
+            <th>Created at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {moves.map((m, i) => (
+            <tr key={m.id}>
+              <td className="ta-right num-col">{i + 1}</td>
+              <td className="ta-right num-col">{fmtNum(m.prev_stop_base, 4)}</td>
+              <td className="ta-right num-col">{fmtNum(m.new_stop_base, 4)}</td>
+              <td className="ta-right num-col">{fmtNum(m.prev_stop_trigger, 4)}</td>
+              <td className="ta-right num-col">{fmtNum(m.new_stop_trigger, 4)}</td>
+              <td className="ta-right num-col">{new Date(m.candle_time).toISOString().replace('T', ' ').slice(0, 19)}</td>
+              <td>{m.created_at}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </div>

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -298,3 +298,132 @@ async def test_summary_metrics_present(monkeypatch):
     )
     required_keys = {"net_profit", "net_profit_pct", "max_drawdown_pct", "sharpe", "n_trades", "win_rate_pct"}
     assert required_keys.issubset(set(result.summary.keys()))
+
+
+# ---------------------------------------------------------------------------
+# move_stop handling in backtest
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedStrategy:
+    """Minimal strategy stub used to drive exact signals into the backtest loop."""
+
+    name = "scripted"
+    description = "scripted signals (test only)"
+
+    def __init__(self, scripted):
+        self._scripted = scripted
+
+    def get_parameters(self):
+        return []
+
+    def init(self, params, candles):
+        return None
+
+    def on_candle(self, t, candle, state):
+        return list(self._scripted(t, candle, state))
+
+
+def _patch_strategy(monkeypatch, scripted):
+    """Register a scripted strategy as 'breakout' for the duration of the test."""
+    from backend.strategies import _REGISTRY
+
+    class _Factory:
+        name = "scripted"
+
+        def __new__(cls):
+            return _ScriptedStrategy(scripted)
+
+    monkeypatch.setitem(_REGISTRY, "scripted", _Factory)
+
+
+@pytest.mark.asyncio
+async def test_backtest_applies_move_stop(monkeypatch):
+    """A move_stop signal must tighten state.stop_price without closing the trade,
+    and a subsequent stop_long must exit at the updated level."""
+    from backend.strategies.base import Signal
+
+    step = INTERVAL_MS["1d"]
+    # 6 flat candles around price 100, then a plunge that triggers the stop.
+    candles = [
+        _make_row(step * 0, 100, 101, 99, 100),
+        _make_row(step * 1, 100, 101, 99, 100),
+        _make_row(step * 2, 100, 101, 99, 100),
+        _make_row(step * 3, 100, 101, 99, 100),
+        _make_row(step * 4, 100, 101, 80, 85),  # low 80 triggers stop
+        _make_row(step * 5, 85, 86, 84, 85),
+    ]
+    _patch_candles(monkeypatch, candles)
+
+    def script(t, candle, state):
+        # Enter long at t=0 with stop=90
+        if t == 0 and state.side == "flat":
+            return [Signal(action="entry_long", price=100.0, stop_price=90.0)]
+        # Move stop up to 95 at t=2
+        if t == 2 and state.side == "long":
+            return [Signal(action="move_stop", stop_price=95.0)]
+        # At t=4 the low (80) is below the new stop (95), so emit stop_long at the new level
+        if t == 4 and state.side == "long" and float(candle["low"]) <= state.stop_price:
+            return [Signal(action="stop_long", price=state.stop_price)]
+        return []
+
+    _patch_strategy(monkeypatch, script)
+
+    result = await run_backtest(
+        symbol="BTCUSDT",
+        interval="1d",
+        start_ms=0,
+        end_ms=step * 6,
+        strategy_name="scripted",
+        params={"modo_ejecucion": "close_current"},
+        initial_capital=10_000.0,
+    )
+
+    assert result.error is None
+    assert len(result.trade_log) == 1
+    trade = result.trade_log[0]
+    assert trade["exit_reason"] == "stop_long"
+    # Exit should happen at the tightened stop (95), not the initial stop (90).
+    assert trade["exit_price"] == pytest.approx(95.0, abs=0.5)
+
+
+@pytest.mark.asyncio
+async def test_backtest_rejects_loosening_move_stop(monkeypatch):
+    """A move_stop that loosens the stop must be ignored."""
+    from backend.strategies.base import Signal
+
+    step = INTERVAL_MS["1d"]
+    candles = [
+        _make_row(step * 0, 100, 101, 99, 100),
+        _make_row(step * 1, 100, 101, 99, 100),
+        _make_row(step * 2, 100, 101, 88, 90),  # low 88 — below 90 (initial) but above any looser stop
+        _make_row(step * 3, 90, 91, 89, 90),
+    ]
+    _patch_candles(monkeypatch, candles)
+
+    def script(t, candle, state):
+        if t == 0 and state.side == "flat":
+            return [Signal(action="entry_long", price=100.0, stop_price=90.0)]
+        # Try to loosen: move stop down from 90 to 80 — must be ignored.
+        if t == 1 and state.side == "long":
+            return [Signal(action="move_stop", stop_price=80.0)]
+        # At t=2, low 88 is below initial stop (90), so stop fires at 90.
+        if t == 2 and state.side == "long" and float(candle["low"]) <= state.stop_price:
+            return [Signal(action="stop_long", price=state.stop_price)]
+        return []
+
+    _patch_strategy(monkeypatch, script)
+
+    result = await run_backtest(
+        symbol="BTCUSDT",
+        interval="1d",
+        start_ms=0,
+        end_ms=step * 4,
+        strategy_name="scripted",
+        params={"modo_ejecucion": "close_current"},
+        initial_capital=10_000.0,
+    )
+
+    assert len(result.trade_log) == 1
+    # Exit at the original stop (90), proving the loosening move was ignored.
+    assert result.trade_log[0]["exit_price"] == pytest.approx(90.0, abs=0.5)

--- a/tests/test_breakout_trailing_strategy.py
+++ b/tests/test_breakout_trailing_strategy.py
@@ -1,0 +1,122 @@
+"""Tests for BreakoutTrailingStrategy: verifies move_stop emission rules."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backend.download_engine import INTERVAL_MS
+from backend.strategies.base import PositionState
+from backend.strategies.breakout_trailing import BreakoutTrailingStrategy
+
+
+def _make_df(closes, highs=None, lows=None, opens=None) -> pd.DataFrame:
+    n = len(closes)
+    if highs is None:
+        highs = [c + 1.0 for c in closes]
+    if lows is None:
+        lows = [c - 1.0 for c in closes]
+    if opens is None:
+        opens = closes
+
+    step = INTERVAL_MS["1d"]
+    return pd.DataFrame(
+        {
+            "open_time": [step * i for i in range(n)],
+            "open": [float(v) for v in opens],
+            "high": [float(v) for v in highs],
+            "low": [float(v) for v in lows],
+            "close": [float(v) for v in closes],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _init_strategy(df, **params):
+    defaults = {
+        "N_entrada": 5,
+        "M_salida": 3,
+        "stop_pct": 0.05,
+        "modo_ejecucion": "open_next",
+        "habilitar_long": True,
+        "habilitar_short": True,
+        "coste_total_bps": 10.0,
+        "trailing_lookback": 3,
+    }
+    defaults.update(params)
+    strat = BreakoutTrailingStrategy()
+    strat.init(defaults, df)
+    return strat
+
+
+def test_long_move_stop_emitted_when_rolling_min_rises():
+    """With a long open, a newer trailing-Min above the current stop should emit move_stop."""
+    # Rising candles: trailing min keeps climbing.
+    lows = [90, 91, 92, 93, 94, 95, 96]
+    closes = [100, 101, 102, 103, 104, 105, 106]
+    highs = [c + 1 for c in closes]
+    df = _make_df(closes, highs=highs, lows=lows)
+    strat = _init_strategy(df, trailing_lookback=3, stop_pct=0.02)
+
+    # Position open, current stop below the trailing candidate.
+    state = PositionState(side="long", entry_price=100.0, stop_price=80.0, quantity=10.0)
+    signals = strat.on_candle(6, df.iloc[6], state)
+
+    move_signals = [s for s in signals if s.action == "move_stop"]
+    assert len(move_signals) == 1
+    # Trailing min at t=6 over [t-3..t-1] = lows[3..5] = min(93,94,95) = 93
+    # stop candidate = 93 * (1 - 0.02) = 91.14
+    assert abs(move_signals[0].stop_price - 93.0 * (1 - 0.02)) < 1e-6
+
+
+def test_long_no_move_stop_when_trailing_would_loosen():
+    """Current stop is already tighter than the trailing candidate → no move_stop."""
+    lows = [90, 91, 92, 93, 94, 95, 96]
+    closes = [100, 101, 102, 103, 104, 105, 106]
+    df = _make_df(closes, highs=[c + 1 for c in closes], lows=lows)
+    strat = _init_strategy(df, trailing_lookback=3, stop_pct=0.02)
+
+    # Stop already above trailing candidate (93*0.98 = 91.14).
+    state = PositionState(side="long", entry_price=100.0, stop_price=95.0, quantity=10.0)
+    signals = strat.on_candle(6, df.iloc[6], state)
+    assert not any(s.action == "move_stop" for s in signals)
+
+
+def test_short_move_stop_mirror_behaviour():
+    """With a short open, a newer trailing-Max below current stop should emit move_stop."""
+    highs = [110, 109, 108, 107, 106, 105, 104]
+    closes = [100, 99, 98, 97, 96, 95, 94]
+    lows = [c - 1 for c in closes]
+    df = _make_df(closes, highs=highs, lows=lows)
+    strat = _init_strategy(df, trailing_lookback=3, stop_pct=0.02)
+
+    state = PositionState(side="short", entry_price=100.0, stop_price=120.0, quantity=10.0)
+    signals = strat.on_candle(6, df.iloc[6], state)
+
+    move_signals = [s for s in signals if s.action == "move_stop"]
+    assert len(move_signals) == 1
+    # Trailing max at t=6 over lows/highs[3..5] = max(107,106,105) = 107
+    # stop candidate = 107 * (1 + 0.02) = 109.14
+    assert abs(move_signals[0].stop_price - 107.0 * (1 + 0.02)) < 1e-6
+
+
+def test_no_move_stop_when_flat():
+    df = _make_df([100, 101, 102, 103, 104, 105, 106])
+    strat = _init_strategy(df)
+    state = PositionState()  # flat
+    signals = strat.on_candle(6, df.iloc[6], state)
+    assert not any(s.action == "move_stop" for s in signals)
+
+
+def test_base_entry_still_works():
+    """Inheritance must not break the base entry logic."""
+    # Breakout up: long breakout on candle 6.
+    closes = [100, 100, 100, 100, 100, 100, 150]
+    highs = [101, 101, 101, 101, 101, 101, 151]
+    lows = [99, 99, 99, 99, 99, 99, 149]
+    df = _make_df(closes, highs=highs, lows=lows)
+    strat = _init_strategy(df, N_entrada=5, stop_pct=0.02)
+
+    state = PositionState()  # flat
+    signals = strat.on_candle(6, df.iloc[6], state)
+    entries = [s for s in signals if s.action == "entry_long"]
+    assert len(entries) == 1

--- a/tests/test_live_tracker.py
+++ b/tests/test_live_tracker.py
@@ -12,9 +12,11 @@ import pytest
 from backend.database import get_db, init_db
 from backend.download_engine import INTERVAL_MS
 from backend.live_tracker import (
+    _apply_stop_moves,
     _check_intrabar_stops,
     _fill_pending_entries,
 )
+from backend.strategies.base import PositionState, Signal
 
 
 @pytest.fixture(autouse=True)
@@ -460,4 +462,185 @@ class TestPendingEntryFill:
             row = await cursor.fetchone()
         assert row[0] == "open"
         assert row[1] == pytest.approx(50000.0, abs=0.01)
-        assert row[2] is not None and row[2] > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Trailing stop (_apply_stop_moves)
+# ---------------------------------------------------------------------------
+
+
+def _trade_row(
+    trade_id: int,
+    signal_id: int,
+    config_id: int,
+    *,
+    side="long",
+    entry_price=100.0,
+    stop_base=95.0,
+    stop_trigger=93.1,
+    stop_cross_pct=0.02,
+) -> dict:
+    """Build the in-memory dict shape _check_candle_close_exits passes in."""
+    return {
+        "id": trade_id,
+        "signal_id": signal_id,
+        "config_id": config_id,
+        "symbol": "BTCUSDT",
+        "interval": "1h",
+        "side": side,
+        "entry_price": entry_price,
+        "entry_time": 1_000_000,
+        "stop_base": stop_base,
+        "stop_trigger": stop_trigger,
+        "stop_cross_pct": stop_cross_pct,
+        "quantity": 100.0,
+        "portfolio": 10_000.0,
+        "invested_amount": 10_000.0,
+        "fees": 10.0,
+        "cost_bps": 10.0,
+    }
+
+
+class TestApplyStopMoves:
+    @pytest.mark.asyncio
+    async def test_long_tightening_move_updates_trade_and_records_history(self):
+        await _setup_db()
+        config_id = await _insert_config()
+        signal_id = await _insert_signal(config_id)
+        trade_id = await _insert_sim_trade(signal_id, config_id, stop_base=95.0, stop_trigger=93.1)
+        trade = _trade_row(trade_id, signal_id, config_id, stop_base=95.0, stop_trigger=93.1)
+        state = PositionState(side="long", entry_price=100.0, stop_price=93.1, quantity=100.0)
+
+        with patch("backend.live_tracker.notify_event", new=AsyncMock()) as mock_notify:
+            await _apply_stop_moves(
+                trade,
+                [Signal(action="move_stop", stop_price=98.0)],
+                candle_open_time=1_100_000,
+                state=state,
+            )
+
+        async with get_db() as db:
+            cursor = await db.execute(
+                "SELECT stop_base, stop_trigger FROM sim_trades WHERE id = ?",
+                (trade_id,),
+            )
+            trade_row = await cursor.fetchone()
+            cursor = await db.execute(
+                """SELECT prev_stop_base, new_stop_base, prev_stop_trigger,
+                          new_stop_trigger, candle_time
+                   FROM sim_trade_stop_moves WHERE sim_trade_id = ?""",
+                (trade_id,),
+            )
+            move_row = await cursor.fetchone()
+
+        assert trade_row[0] == pytest.approx(98.0)
+        assert trade_row[1] == pytest.approx(98.0 * (1.0 - 0.02))
+        assert move_row is not None
+        assert move_row[0] == pytest.approx(95.0)
+        assert move_row[1] == pytest.approx(98.0)
+        assert move_row[4] == 1_100_000
+
+        # In-memory state mirrors the trigger for later same-candle checks.
+        assert state.stop_price == pytest.approx(98.0 * (1.0 - 0.02))
+        mock_notify.assert_called_once()
+        kwargs = mock_notify.call_args.kwargs
+        assert kwargs["event_type"] == "stop_moved"
+        assert kwargs["reference_type"] == "sim_trade_stop_move"
+        assert kwargs["payload"]["prev_stop"] == pytest.approx(95.0)
+        assert kwargs["payload"]["new_stop"] == pytest.approx(98.0)
+
+    @pytest.mark.asyncio
+    async def test_short_tightening_move_updates_trade(self):
+        await _setup_db()
+        config_id = await _insert_config()
+        signal_id = await _insert_signal(config_id, side="short", stop_price=105.0, stop_trigger=107.1)
+        trade_id = await _insert_sim_trade(
+            signal_id,
+            config_id,
+            side="short",
+            entry_price=100.0,
+            stop_base=105.0,
+            stop_trigger=107.1,
+        )
+        trade = _trade_row(
+            trade_id, signal_id, config_id, side="short", entry_price=100.0, stop_base=105.0, stop_trigger=107.1
+        )
+        state = PositionState(side="short", entry_price=100.0, stop_price=107.1, quantity=100.0)
+
+        with patch("backend.live_tracker.notify_event", new=AsyncMock()):
+            await _apply_stop_moves(
+                trade,
+                [Signal(action="move_stop", stop_price=102.0)],
+                candle_open_time=1_100_000,
+                state=state,
+            )
+
+        async with get_db() as db:
+            cursor = await db.execute(
+                "SELECT stop_base, stop_trigger FROM sim_trades WHERE id = ?",
+                (trade_id,),
+            )
+            row = await cursor.fetchone()
+        assert row[0] == pytest.approx(102.0)
+        assert row[1] == pytest.approx(102.0 * (1.0 + 0.02))
+
+    @pytest.mark.asyncio
+    async def test_loosening_move_is_rejected(self):
+        """A move_stop that would loosen the stop must not change anything."""
+        await _setup_db()
+        config_id = await _insert_config()
+        signal_id = await _insert_signal(config_id)
+        trade_id = await _insert_sim_trade(signal_id, config_id, stop_base=95.0, stop_trigger=93.1)
+        trade = _trade_row(trade_id, signal_id, config_id, stop_base=95.0, stop_trigger=93.1)
+        state = PositionState(side="long", entry_price=100.0, stop_price=93.1, quantity=100.0)
+
+        with patch("backend.live_tracker.notify_event", new=AsyncMock()) as mock_notify:
+            await _apply_stop_moves(
+                trade,
+                [Signal(action="move_stop", stop_price=90.0)],  # lower than current 95.0
+                candle_open_time=1_100_000,
+                state=state,
+            )
+
+        async with get_db() as db:
+            cursor = await db.execute(
+                "SELECT stop_base, stop_trigger FROM sim_trades WHERE id = ?",
+                (trade_id,),
+            )
+            row = await cursor.fetchone()
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM sim_trade_stop_moves WHERE sim_trade_id = ?",
+                (trade_id,),
+            )
+            count = (await cursor.fetchone())[0]
+
+        assert row[0] == pytest.approx(95.0)
+        assert row[1] == pytest.approx(93.1)
+        assert count == 0
+        mock_notify.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_move_stop_signal_is_noop(self):
+        await _setup_db()
+        config_id = await _insert_config()
+        signal_id = await _insert_signal(config_id)
+        trade_id = await _insert_sim_trade(signal_id, config_id, stop_base=95.0, stop_trigger=93.1)
+        trade = _trade_row(trade_id, signal_id, config_id)
+        state = PositionState(side="long", entry_price=100.0, stop_price=93.1, quantity=100.0)
+
+        with patch("backend.live_tracker.notify_event", new=AsyncMock()) as mock_notify:
+            await _apply_stop_moves(
+                trade,
+                [Signal(action="exit_long", price=99.0)],
+                candle_open_time=1_100_000,
+                state=state,
+            )
+
+        async with get_db() as db:
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM sim_trade_stop_moves WHERE sim_trade_id = ?",
+                (trade_id,),
+            )
+            count = (await cursor.fetchone())[0]
+        assert count == 0
+        mock_notify.assert_not_called()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -278,3 +278,76 @@ async def test_unknown_event_type_is_rejected():
         )
 
     mock_send.assert_not_called()
+
+
+def test_format_stop_moved_renders_required_fields():
+    """The stop_moved formatter produces a message with prev/new stop levels and locked pct."""
+    from backend.notifications import _format_stop_moved
+
+    text = _format_stop_moved(
+        {
+            "symbol": "BTCUSDT",
+            "side": "long",
+            "interval": "1h",
+            "prev_stop": 95.12345,
+            "new_stop": 98.50000,
+            "locked_pct": 0.015,
+            "sim_trade_id": 42,
+        }
+    )
+
+    assert "Stop movido" in text
+    assert "BTCUSDT" in text
+    assert "95." in text
+    assert "98." in text
+    assert "Ganancia bloqueada" in text
+
+
+def test_format_stop_moved_omits_locked_pct_when_missing():
+    from backend.notifications import _format_stop_moved
+
+    text = _format_stop_moved(
+        {
+            "symbol": "BTCUSDT",
+            "side": "short",
+            "interval": "4h",
+            "prev_stop": 105.0,
+            "new_stop": 102.0,
+            "sim_trade_id": 7,
+        }
+    )
+    assert "Ganancia bloqueada" not in text
+
+
+@pytest.mark.asyncio
+async def test_stop_moved_event_goes_through_dispatcher():
+    """stop_moved is a recognised event: dispatcher writes to the log and sends Telegram."""
+    from backend.notifications import notify_event
+
+    await init_db()
+    user_id = await _insert_user(chat_id=12345, username="trader")
+    config_id = await _insert_config(user_id, telegram_enabled=True)
+
+    with (
+        patch("backend.notifications.send_message", new=AsyncMock(return_value=True)) as mock_send,
+        patch("backend.notifications.TELEGRAM_ENABLED", True),
+    ):
+        await notify_event(
+            event_type="stop_moved",
+            config_id=config_id,
+            reference_type="sim_trade_stop_move",
+            reference_id=1,
+            payload={
+                "symbol": "BTCUSDT",
+                "side": "long",
+                "interval": "1h",
+                "prev_stop": 95.0,
+                "new_stop": 98.0,
+                "locked_pct": 0.02,
+                "sim_trade_id": 1,
+            },
+        )
+
+    assert mock_send.call_count == 1
+    assert await _count_log("internal") == 1
+    assert await _count_log("telegram") == 1

--- a/tests/test_support_resistance_trailing_strategy.py
+++ b/tests/test_support_resistance_trailing_strategy.py
@@ -1,0 +1,114 @@
+"""Tests for SupportResistanceTrailingStrategy: verifies move_stop emission rules."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from backend.download_engine import INTERVAL_MS
+from backend.strategies.base import PositionState
+from backend.strategies.support_resistance_trailing import SupportResistanceTrailingStrategy
+
+
+def _make_df(closes, highs=None, lows=None, opens=None) -> pd.DataFrame:
+    n = len(closes)
+    if highs is None:
+        highs = [c + 1.0 for c in closes]
+    if lows is None:
+        lows = [c - 1.0 for c in closes]
+    if opens is None:
+        opens = closes
+
+    step = INTERVAL_MS["1d"]
+    return pd.DataFrame(
+        {
+            "open_time": [step * i for i in range(n)],
+            "open": [float(v) for v in opens],
+            "high": [float(v) for v in highs],
+            "low": [float(v) for v in lows],
+            "close": [float(v) for v in closes],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _init_strategy(df, **params):
+    defaults = {
+        "reversal_pct": 0.05,
+        "stop_pct": 0.02,
+        "modo_ejecucion": "open_next",
+        "habilitar_long": True,
+        "habilitar_short": True,
+        "coste_total_bps": 10.0,
+    }
+    defaults.update(params)
+    strat = SupportResistanceTrailingStrategy()
+    strat.init(defaults, df)
+    return strat
+
+
+def test_long_move_stop_when_support_tightens():
+    """When last_support at t yields a higher candidate than state.stop_price, emit move_stop."""
+    df = _make_df([100] * 10)
+    strat = _init_strategy(df, stop_pct=0.02)
+    # Force a confirmed support at the current candle.
+    strat.last_support = np.full(10, 95.0)
+    strat.last_resistance = np.full(10, 110.0)
+
+    state = PositionState(side="long", entry_price=100.0, stop_price=80.0, quantity=10.0)
+    signals = strat.on_candle(5, df.iloc[5], state)
+    moves = [s for s in signals if s.action == "move_stop"]
+    assert len(moves) == 1
+    assert abs(moves[0].stop_price - 95.0 * (1 - 0.02)) < 1e-6
+
+
+def test_long_no_move_stop_when_support_unchanged():
+    """If candidate equals current stop (no tightening), no move_stop."""
+    df = _make_df([100] * 10)
+    strat = _init_strategy(df, stop_pct=0.02)
+    strat.last_support = np.full(10, 95.0)
+    strat.last_resistance = np.full(10, 110.0)
+
+    current_stop = 95.0 * (1 - 0.02)
+    state = PositionState(side="long", entry_price=100.0, stop_price=current_stop, quantity=10.0)
+    signals = strat.on_candle(5, df.iloc[5], state)
+    assert not any(s.action == "move_stop" for s in signals)
+
+
+def test_short_move_stop_when_resistance_tightens():
+    df = _make_df([100] * 10)
+    strat = _init_strategy(df, stop_pct=0.02)
+    strat.last_support = np.full(10, 90.0)
+    strat.last_resistance = np.full(10, 105.0)
+
+    state = PositionState(side="short", entry_price=100.0, stop_price=120.0, quantity=10.0)
+    signals = strat.on_candle(5, df.iloc[5], state)
+    moves = [s for s in signals if s.action == "move_stop"]
+    assert len(moves) == 1
+    assert abs(moves[0].stop_price - 105.0 * (1 + 0.02)) < 1e-6
+
+
+def test_no_move_stop_before_levels_confirmed():
+    df = _make_df([100] * 10)
+    strat = _init_strategy(df)
+    # Levels still NaN (no confirmed support/resistance yet).
+    strat.last_support = np.full(10, np.nan)
+    strat.last_resistance = np.full(10, np.nan)
+
+    state = PositionState(side="long", entry_price=100.0, stop_price=80.0, quantity=10.0)
+    signals = strat.on_candle(5, df.iloc[5], state)
+    assert not any(s.action == "move_stop" for s in signals)
+
+
+def test_base_stop_signal_preempts_move_stop():
+    """If the base strategy emits stop_long in the same candle, no trailing move is appended."""
+    df = _make_df([100] * 10, lows=[c - 0.5 for c in [100] * 10])
+    strat = _init_strategy(df, stop_pct=0.02)
+    strat.last_support = np.full(10, 95.0)
+    strat.last_resistance = np.full(10, 110.0)
+
+    # state.stop_price is above today's low, so base will fire stop_long.
+    state = PositionState(side="long", entry_price=100.0, stop_price=150.0, quantity=10.0)
+    signals = strat.on_candle(5, df.iloc[5], state)
+    assert any(s.action == "stop_long" for s in signals)
+    assert not any(s.action == "move_stop" for s in signals)


### PR DESCRIPTION
## Resumen

Implementación completa del soporte de trailing stop en backtest y live, con auditoría en BD, endpoint API y evento Telegram `stop_moved`.

- Nueva acción `move_stop` en `Signal`; `PositionState.stop_price` ahora es mutable durante la vida del trade.
- `backtest_engine` procesa `move_stop` antes del dispatch de exits, con **safety guard** de monotonicidad (long: sólo sube, short: sólo baja).
- `live_tracker._apply_stop_moves` aplica el mismo invariante, recalcula `stop_trigger = stop_base × (1 ∓ stop_cross_pct)`, hace UPDATE en `sim_trades`, inserta un row en la nueva tabla `sim_trade_stop_moves` y dispara `notify_event("stop_moved", …)` con `reference_type="sim_trade_stop_move"` para permitir N movimientos por trade sin colisionar con el dedup.
- Dos variantes nuevas — `breakout_trailing` y `support_resistance_trailing` — **heredan** de las estrategias existentes (intactas, su rentabilidad no se toca) y sólo añaden la emisión de `move_stop`.
- Endpoint `GET /api/sim-trades/{id}/stop-moves` + fila expandible en `SignalsPanel.jsx` que lista los movimientos.
- Tabla nueva en `init_db()` (SQLite) y revisión Alembic `004_trailing_stop.py` en lockstep.
- 16 tests nuevos; suite total: 190 passing.

## Validación

- `ruff check` + `ruff format --check` OK
- `pytest -q` → 190/190
- `npm run lint` y `npm run build` OK
- Smoke e2e con Playwright sobre stack local (backend + vite) + datos sembrados: la expansión de la fila muestra los movimientos de stop y el propio `live_tracker` aplicó un `move_stop` real sobre velas reales de BTCUSDT durante la prueba.

## Test plan

- [ ] Mergear a develop → CI construye imagen dev → Argo CD despliega.
- [ ] En dev: crear un `signal_config` con `breakout_trailing` sobre BTCUSDT 1h.
- [ ] Dejarlo correr; cuando se abra un sim_trade, observar en el panel cómo aparecen movimientos en la fila expandida.
- [ ] Con `telegram_enabled=1` y un chat vinculado, confirmar llegada del mensaje 🎯 "Stop movido".

## Follow-ups (issues aparte)

1. Pintar la evolución del stop en `TradeReviewChart` (`lightweight-charts`).
2. Paridad backtest ↔ live aplicando `stop_cross_pct` también en backtest.

Closes #36