### PR TITLE
feat(ui): paint trailing-stop curve on TradeReviewChart (#44)

### DIFF
--- a/frontend/src/components/SignalsPanel.jsx
+++ b/frontend/src/components/SignalsPanel.jsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { apiFetch } from '../auth/apiFetch'
+import TradeReviewChart from './TradeReviewChart'
 
 const PAIRS = [
   'BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT',
@@ -563,7 +564,7 @@ function SimTradesList({ trades, onClose }) {
                 {isExpanded && (
                   <tr>
                     <td colSpan={14} style={{ background: 'var(--surface-1)', padding: 'var(--space-3)' }}>
-                      <StopMovesDetail moves={moves} loading={loadingMoves && moves === undefined} />
+                      <SimTradeReview trade={t} moves={moves} loadingMoves={loadingMoves && moves === undefined} />
                     </td>
                   </tr>
                 )}
@@ -572,6 +573,59 @@ function SimTradesList({ trades, onClose }) {
           })}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+function SimTradeReview({ trade, moves, loadingMoves }) {
+  // Capture "now" once at mount so the render function stays pure for the
+  // React Compiler. Open trades (no exit_time) chart up to this snapshot.
+  const [nowMs] = useState(() => Date.now())
+
+  const { startMs, endMs } = useMemo(() => {
+    const stepBy = {
+      '1h': 60 * 60 * 1000,
+      '2h': 2 * 60 * 60 * 1000,
+      '4h': 4 * 60 * 60 * 1000,
+      '6h': 6 * 60 * 60 * 1000,
+      '8h': 8 * 60 * 60 * 1000,
+      '12h': 12 * 60 * 60 * 1000,
+      '1d': 24 * 60 * 60 * 1000,
+      '3d': 3 * 24 * 60 * 60 * 1000,
+      '1w': 7 * 24 * 60 * 60 * 1000,
+      '1M': 30 * 24 * 60 * 60 * 1000,
+    }
+    const STEP_MS = stepBy[trade.interval] || 24 * 60 * 60 * 1000
+    const entryMs = Number(trade.entry_time) || nowMs
+    const exitMs = Number(trade.exit_time) || nowMs
+    return {
+      startMs: Math.max(0, entryMs - 50 * STEP_MS),
+      endMs: exitMs + 10 * STEP_MS,
+    }
+  }, [trade.interval, trade.entry_time, trade.exit_time, nowMs])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+      {trade.entry_time && (
+        <TradeReviewChart
+          symbol={trade.symbol}
+          interval={trade.interval}
+          startMs={startMs}
+          endMs={endMs}
+          trades={[{
+            id: trade.id,
+            side: trade.side,
+            entry_time: trade.entry_time,
+            exit_time: trade.exit_time ?? endMs,
+            entry_price: trade.entry_price,
+            exit_price: trade.exit_price,
+            pnl: trade.pnl,
+            exit_reason: trade.exit_reason,
+            stop_base: trade.stop_base,
+          }]}
+        />
+      )}
+      <StopMovesDetail moves={moves} loading={loadingMoves} />
     </div>
   )
 }

--- a/frontend/src/components/TradeReviewChart.jsx
+++ b/frontend/src/components/TradeReviewChart.jsx
@@ -141,6 +141,69 @@ export default function TradeReviewChart({ symbol, interval, startMs, endMs, tra
           // lightweight-charts requires markers sorted by time
           markers.sort((a, b) => a.time - b.time)
           candleSeries.setMarkers(markers)
+
+          // ---- Stop-loss curves (#44): one line series per sim_trade with id +
+          // stop_base. Fetches the trailing-stop history; renders a stepped
+          // segment per move. Backtest trades (no id) are skipped.
+          await Promise.all(
+            trades.map(async (trade) => {
+              if (cancelled) return
+              if (!trade.id || trade.stop_base == null) return
+              const initialStop = parseFloat(trade.stop_base)
+              const entryTimeS = Math.floor(Number(trade.entry_time) / 1000)
+              const exitTimeS = trade.exit_time
+                ? Math.floor(Number(trade.exit_time) / 1000)
+                : ohlcData[ohlcData.length - 1]?.time
+              if (!entryTimeS || !exitTimeS) return
+
+              let moves = []
+              try {
+                const r = await apiFetch(`/api/sim-trades/${trade.id}/stop-moves`)
+                if (r.ok) moves = (await r.json()).stop_moves ?? []
+              } catch {
+                // silent — chart still renders without trailing line
+              }
+              if (cancelled || !chartRef.current) return
+
+              // Build stepped points: [entry, initial_stop] → at each move
+              // candle_time, two points (prev level then new level) to draw
+              // the vertical step → final point at exit_time at the last
+              // active level.
+              const points = []
+              let level = initialStop
+              points.push({ time: entryTimeS, value: level })
+              for (const m of moves) {
+                const t = Math.floor(Number(m.candle_time) / 1000)
+                if (t <= entryTimeS || t > exitTimeS) continue
+                // Hold previous level up to the move's candle, then jump.
+                points.push({ time: t, value: level })
+                level = parseFloat(m.new_stop_base)
+                points.push({ time: t, value: level })
+              }
+              // Close the last segment at exit_time.
+              if (points[points.length - 1].time !== exitTimeS) {
+                points.push({ time: exitTimeS, value: level })
+              }
+              // De-duplicate adjacent points sharing the same time (keep the
+              // last value so the visual jump renders).
+              const compact = []
+              for (const p of points) {
+                const prev = compact[compact.length - 1]
+                if (prev && prev.time === p.time) compact[compact.length - 1] = p
+                else compact.push(p)
+              }
+
+              const stopSeries = chartRef.current.addLineSeries({
+                color: 'rgba(245, 158, 11, 0.85)',  // amber, distinct from entry/exit
+                lineWidth: 2,
+                lineStyle: 2,  // dashed
+                priceLineVisible: false,
+                lastValueVisible: false,
+                title: `Stop · #${trade.id}`,
+              })
+              stopSeries.setData(compact)
+            })
+          )
         }
 
         chart.timeScale().fitContent()
@@ -197,6 +260,8 @@ export default function TradeReviewChart({ symbol, interval, startMs, endMs, tra
           <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Exit (profit)</span>
           <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#f59e0b', display: 'inline-block', marginLeft: 8 }} />
           <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Exit (loss)</span>
+          <span style={{ width: 14, height: 0, borderTop: '2px dashed rgba(245, 158, 11, 0.85)', display: 'inline-block', marginLeft: 8 }} />
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Stop level (sim trades)</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- TradeReviewChart now paints a stepped horizontal line (amber, dashed) for every trade that carries a sim_trade \`id\` plus an initial \`stop_base\`. The line traces the trailing-stop history from \`sim_trade_stop_moves\`.
- Wires the chart into \`SignalsPanel\`: clicking the expand button on a sim_trade row now shows a candle chart with the trailing-stop curve overlaid, plus the existing stop-moves table below it.
- Trades without an \`id\` (backtest trade_log entries) are unaffected — same markers, same candlestick.

## Why

Issue #44: visual review of trailing-stop progression alongside the candle chart so users can see where each stop move happened in price context, not just a row number in a table.

## Closes

- Closes #44.

## What's in

- \`TradeReviewChart.jsx\`:
  - For every input trade with \`{id, stop_base, entry_time}\`: fetches \`GET /api/sim-trades/{id}/stop-moves\`, builds stepped \`{time, value}\` points, and adds a dashed amber \`addLineSeries\` per trade.
  - Open trades close the line at the chart's right edge.
  - Adds a legend entry for \"Stop level (sim trades)\".
- \`SignalsPanel.jsx\`:
  - New \`SimTradeReview\` component combines the chart and the moves table inside the expanded row.
  - Uses \`useMemo\` + a \`useState\` lazy-init snapshot of \`Date.now()\` so the render path stays pure under the React Compiler / new \`react-hooks/purity\` rule.

## Out of scope

- Backtest trades don't get the stop curve — backtest trade_log doesn't carry the trailing-stop history (engine doesn't persist it). Adding it would require enhancing \`backtest_engine\` to record per-trade stop progression. Tracked separately if needed.
- Tooltips on individual move points are not added (lightweight-charts doesn't expose per-point tooltips on line series natively). The stop-moves table remains the source-of-truth for exact prev/new values.

## Test plan

- [x] \`npm --prefix frontend run lint\` — clean (1 pre-existing unused-eslint-disable warning, unrelated).
- [x] \`npm --prefix frontend run build\` — clean.
- [x] \`pytest -q\` — 195 passed (no test changes; verified parity harness still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)