### PR TITLE
ci(security): baseline CI hardening — Dependabot, Trivy, gitleaks (#63 Sprint 0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      python-patches:
+        update-types:
+          - patch
+    labels:
+      - dependencies
+      - python
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      npm-patches:
+        update-types:
+          - patch
+    labels:
+      - dependencies
+      - frontend
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - ci
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - docker

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -21,6 +21,7 @@ jobs:
       packages: write
     outputs:
       short_sha: ${{ steps.sha.outputs.short }}
+      image_digest: ${{ steps.build.outputs.digest }}
 
     steps:
       - uses: actions/checkout@v6
@@ -43,6 +44,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -63,9 +65,36 @@ jobs:
           min-versions-to-keep: 5
           delete-only-untagged-versions: false
 
+  scan-image:
+    name: Trivy scan (HIGH/CRITICAL blocks promotion)
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image_digest }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+          vuln-type: os,library
+
   update-tag:
     name: Update dev image tag for Argo CD
-    needs: build-and-push
+    needs:
+      - build-and-push
+      - scan-image
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,29 @@
+name: Secret scan
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+
+jobs:
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    # Non-blocking initially — flips to required once the baseline is clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "true"
+          GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,9 +10,12 @@ on:
       - develop
       - main
 
+env:
+  GITLEAKS_VERSION: "8.21.2"
+
 jobs:
   gitleaks:
-    name: Gitleaks
+    name: Gitleaks (CLI)
     runs-on: ubuntu-latest
     # Non-blocking initially — flips to required once the baseline is clean.
     continue-on-error: true
@@ -21,9 +24,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_COMMENTS: "true"
-          GITLEAKS_ENABLE_SUMMARY: "true"
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Run gitleaks (full git history)
+        run: gitleaks detect --source . --redact --verbose --exit-code 1

--- a/README.md
+++ b/README.md
@@ -230,8 +230,9 @@ Cubren:
 ## Despliegue
 
 - Imagen multi-stage (`Dockerfile`): Node 22 Alpine construye el frontend, Python 3.13-slim corre la app.
-- CD: push a `develop` → GitHub Actions publica imagen multi-arch en GHCR y actualiza `helm/env/dev.yaml` con el tag. Argo CD aplica el cambio al cluster k3s de dev.
-- Chart de Helm en `helm/`; valores sensibles viven en un `Secret` externo referenciado por `existingSecret`.
+- CD: push a `develop` → GitHub Actions publica imagen multi-arch en GHCR, escanea con **Trivy** (HIGH/CRITICAL fixables bloquean) y solo si el scan pasa actualiza `helm/env/dev.yaml` con el tag. Argo CD aplica el cambio al cluster k3s de dev.
+- Chart de Helm en `helm/`; valores sensibles viven en un `Secret` externo referenciado por `existingSecret`. El template está en `helm/env/secrets.example.yaml` — copia a `helm/env/secrets.yaml` (gitignored), rellena con `printf '%s' '<value>' | base64 -w 0`, y aplícalo manualmente con `kubectl apply -f`.
+- CI adicional: **Dependabot** semanal (pip, npm, github-actions, docker) y **gitleaks** en cada PR/push como red de seguridad contra leaks accidentales.
 
 ## Estructura rápida
 

--- a/helm/env/secrets.example.yaml
+++ b/helm/env/secrets.example.yaml
@@ -1,0 +1,39 @@
+# Template for the dev/qa/prod Secret manifest.
+#
+# Copy this file to `helm/env/secrets.yaml` (gitignored) and fill in real values
+# encoded with `printf '%s' '<value>' | base64 -w 0`.
+#
+# Apply manually with `kubectl apply -f helm/env/secrets.yaml` — the file MUST
+# never be committed. The Helm chart references the resulting Secret via
+# `existingSecret` in `helm/env/<env>.yaml`.
+#
+# Required keys:
+#   DATABASE_URL                 — postgresql://user:password@host:5432/db
+#   TELEGRAM_BOT_TOKEN           — bot API token from @BotFather
+#   TELEGRAM_BOT_USERNAME        — bot username without the leading @
+#   TELEGRAM_WEBHOOK_SECRET      — random hex used in path + header
+#   TELEGRAM_WEBHOOK_URL         — full HTTPS URL of the webhook (with secret in path)
+#   PUBLIC_BASE_URL              — public URL of the deployment (for "Ver trade" links)
+#   CLOUDFLARE_TUNNEL_TOKEN      — token from `cloudflared tunnel token <id>`
+#   KEYCLOAK_URL                 — base URL of the Keycloak server
+#   KEYCLOAK_REALM               — realm name (e.g. tradingtool-dev)
+#   KEYCLOAK_AUDIENCE            — JWT audience / API client ID
+#   KEYCLOAK_FRONTEND_CLIENT_ID  — public client used by the SPA
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tradingtools-secret-dev
+  namespace: tradingtool-dev
+type: Opaque
+data:
+  DATABASE_URL: REPLACE_ME_BASE64
+  CLOUDFLARE_TUNNEL_TOKEN: REPLACE_ME_BASE64
+  KEYCLOAK_URL: REPLACE_ME_BASE64
+  KEYCLOAK_REALM: REPLACE_ME_BASE64
+  KEYCLOAK_AUDIENCE: REPLACE_ME_BASE64
+  KEYCLOAK_FRONTEND_CLIENT_ID: REPLACE_ME_BASE64
+  TELEGRAM_BOT_TOKEN: REPLACE_ME_BASE64
+  TELEGRAM_BOT_USERNAME: REPLACE_ME_BASE64
+  TELEGRAM_WEBHOOK_SECRET: REPLACE_ME_BASE64
+  TELEGRAM_WEBHOOK_URL: REPLACE_ME_BASE64
+  PUBLIC_BASE_URL: REPLACE_ME_BASE64


### PR DESCRIPTION
## Summary

Cierra el Sprint 0 del [roadmap cross-cutting](https://github.com/open-liontechsolution/tradingtool/issues/63) sobre #63: defensa proactiva en CI. **No requiere rotación urgente** — el P0 original ("secretos committeados en `helm/env/secrets.yaml`") es un falso positivo: ese archivo nunca estuvo trackeado en git y `.gitignore` ya lo cubre.

- **Dependabot** semanal (lunes) para `pip`, `npm`, `github-actions`, `docker`. Patches agrupados, manual review minor/major.
- **Trivy** scan-image entre `build-and-push` y `update-tag`. CVE HIGH/CRITICAL **fixable** fallan el job, así que `update-tag` no corre y Argo no promociona la imagen vulnerable a dev. La imagen sigue en GHCR (digest accesible para debug) pero el tag de Argo no se actualiza.
- **gitleaks** workflow en cada PR/push a `develop`/`main`. Inicialmente `continue-on-error: true` para no bloquear hasta que la baseline esté limpia.
- **`helm/env/secrets.example.yaml`** como template documentado del Secret real (que sigue gitignored y se aplica a mano con `kubectl apply -f`).
- **README** actualizado con dos líneas en la sección Despliegue.

Tras este PR, el Sprint 1 del roadmap es el QA env (#62). El Sprint 2 ataca CORS, rate limiting y headers (P1/P2 restantes de #63).

## Test plan

- [x] CI: `lint-backend`, `lint-frontend`, `test-backend`, `build-frontend` siguen verdes (no se ha tocado código de la app).
- [x] CI: nuevo workflow `Secret scan / Gitleaks` corre en este PR. `continue-on-error: true` por diseño.
- [x] Tras merge: en el siguiente push a `develop`, el job `Trivy scan` aparece entre `build-and-push` y `update-tag` en `Build & Push Dev Image`.
- [ ] Tras merge: Dependabot abre su primer PR de updates dentro del lunes siguiente.
- [x] Verificar manualmente en GitHub Settings → Code security: native secret-scanning **activo** en el repo público.

🤖 Generated with [Claude Code](https://claude.com/claude-code)