### PR TITLE
fix(ci): trivy-action version pin (0.28.0 → v0.36.0)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -81,7 +81,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image_digest }}
           severity: HIGH,CRITICAL

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Cubren:
 - Imagen multi-stage (`Dockerfile`): Node 22 Alpine construye el frontend, Python 3.13-slim corre la app.
 - CD: push a `develop` → GitHub Actions publica imagen multi-arch en GHCR, escanea con **Trivy** (HIGH/CRITICAL fixables bloquean) y solo si el scan pasa actualiza `helm/env/dev.yaml` con el tag. Argo CD aplica el cambio al cluster k3s de dev.
 - Chart de Helm en `helm/`; valores sensibles viven en un `Secret` externo referenciado por `existingSecret`. El template está en `helm/env/secrets.example.yaml` — copia a `helm/env/secrets.yaml` (gitignored), rellena con `printf '%s' '<value>' | base64 -w 0`, y aplícalo manualmente con `kubectl apply -f`.
-- CI adicional: **Dependabot** semanal (pip, npm, github-actions, docker) y **gitleaks** en cada PR/push como red de seguridad contra leaks accidentales.
+- CI adicional: **Dependabot** semanal (pip, npm, github-actions, docker) y **gitleaks** en cada PR/push como red de seguridad contra leaks accidentales. Versiones pineadas: `aquasecurity/trivy-action@v0.36.0`, `gitleaks` CLI v8.21.2; Dependabot eleva los pins cuando salgan nuevas releases.
 
 ## Estructura rápida
 


### PR DESCRIPTION
## Summary

Hotfix del scan-image job introducido en #64. El pin original `aquasecurity/trivy-action@0.28.0` no existe (typo); la última release de la action es `v0.36.0` (nota: el prefijo `v` volvió a partir de `v0.31.0`).

Sin este fix, cada push a develop falla en el job \`scan-image\` con \`Unable to resolve action aquasecurity/trivy-action@0.28.0\`, lo que también bloquea \`update-tag\` y por tanto la promoción del tag a Argo.

## Test plan

- [ ] Tras merge: el siguiente push a develop ejecuta build-and-push → scan-image (con Trivy v0.36.0) → update-tag.
- [ ] Si la imagen actual tiene CVEs HIGH/CRITICAL fixables, scan-image fallará y update-tag no correrá. Si pasa, Argo recibe el nuevo tag normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)