### PR TITLE
fix(ci): move GHCR cleanup after Trivy scan (manifest race)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -57,14 +57,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Delete old package versions (keep last 5)
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: tradingtools
-          package-type: container
-          min-versions-to-keep: 5
-          delete-only-untagged-versions: false
-
   scan-image:
     name: Trivy scan (HIGH/CRITICAL blocks promotion)
     needs: build-and-push
@@ -125,3 +117,25 @@ jobs:
           git diff --cached --quiet && echo "No changes to commit" && exit 0
           git commit -m "cd(dev): update image tag to dev-${{ needs.build-and-push.outputs.short_sha }}"
           git push origin develop
+
+  cleanup-old-versions:
+    name: Clean up old GHCR package versions
+    needs:
+      - build-and-push
+      - scan-image
+      - update-tag
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Multi-arch images create 1 manifest list + 2 platform children per push.
+      # Keeping 15 versions retains ~5 multi-arch builds. Runs *after* scan-image
+      # and update-tag so we never delete a child manifest that Trivy still
+      # needs to resolve (#63: previous setup borraba children mid-pipeline).
+      - name: Delete old package versions (keep last 15)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tradingtools
+          package-type: container
+          min-versions-to-keep: 15
+          delete-only-untagged-versions: false

--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -83,14 +83,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Delete old package versions (keep last 10)
-        uses: actions/delete-package-versions@v5
-        with:
-          package-name: tradingtools
-          package-type: container
-          min-versions-to-keep: 10
-          delete-only-untagged-versions: false
-
   scan-image:
     name: Trivy scan (HIGH/CRITICAL blocks promotion)
     needs:
@@ -240,3 +232,25 @@ jobs:
             | jq -e ".[] | select(.id == $id)" > /dev/null
           curl -fsS -X DELETE -H "Authorization: Bearer $TOKEN" "$QA_BASE_URL/api/signals/configs/$id"
           echo "Round-trip OK."
+
+  cleanup-old-versions:
+    name: Clean up old GHCR package versions
+    needs:
+      - build-and-push
+      - scan-image
+      - update-tag
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      # Multi-arch images create 1 manifest list + 2 platform children per push.
+      # Keeping 15 versions retains ~5 multi-arch builds. Runs *after* scan-image
+      # and update-tag so we never delete a child manifest that Trivy still
+      # needs to resolve.
+      - name: Delete old package versions (keep last 15)
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: tradingtools
+          package-type: container
+          min-versions-to-keep: 15
+          delete-only-untagged-versions: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ Replays a fixed klines fixture through both the backtest engine and the live eng
 | Build workflow | `.github/workflows/build-dev.yml` | `.github/workflows/build-qa.yml` |
 | Trigger | push to `develop` (every commit) | `workflow_dispatch` (manual) **or** push of tag `v*.*.*-rc*` |
 
-- **dev pipeline**: push to `develop` → `build-dev.yml` builds multi-arch image, scans with Trivy (HIGH/CRITICAL fixable blocks promotion), updates `helm/env/dev.yaml` image tag. Argo `trading-tool` Application is sync-manual, so a human still clicks Sync in the Argo UI.
+- **dev pipeline**: push to `develop` → `build-dev.yml` builds multi-arch image, scans with Trivy (HIGH/CRITICAL fixable blocks promotion), updates `helm/env/dev.yaml` image tag, and finally runs a `cleanup-old-versions` job that prunes GHCR (keep last 15 — multi-arch creates 3 versions per push, so this retains ~5 builds). The cleanup runs **last** because Trivy resolves the manifest-list digest and pulls platform-child manifests; deleting GHCR versions before Trivy finishes can vanish those children mid-scan and break the resolution. Argo `trading-tool` Application is sync-manual, so a human still clicks Sync in the Argo UI.
 - **qa pipeline**: same shape as dev plus a `resolve-tag` job at the front that branches on event:
   - `push: tags: 'v*.*.*-rc*'` → image tag is the version itself (e.g. `v1.2.0-rc1`).
   - `workflow_dispatch` → image tag is `qa-<short_sha>`.


### PR DESCRIPTION
## Summary

Hotfix urgente del pipeline de dev. El Trivy scan del push `bbf3d88` (17:39 UTC) falló con \`MANIFEST_UNKNOWN\` y bloqueó la promoción a Argo.

### Causa raíz

\`actions/delete-package-versions@v5\` corría **dentro** del job \`build-and-push\`, justo después del push y antes de que \`scan-image\` arrancara en su propio job. Para imágenes multi-arch, cada push crea 3 versions en GHCR (1 manifest list + 2 platform children, amd64 + arm64). Con \`min-versions-to-keep: 5\` y dos pushes consecutivos los children del último push entran en la lista de candidatos a borrar (timestamps empatan).

El log del run confirma \`Total versions deleted till now: 4\` justo antes de que Trivy arrancara. Trivy resuelve la manifest list, pilla el digest del child linux/amd64 y lo consulta en GHCR — \`MANIFEST_UNKNOWN\`.

### Fix

- Saco el paso \`Delete old package versions\` del job \`build-and-push\`.
- Lo convierto en un job nuevo \`cleanup-old-versions\` que corre **al final**, dependiendo de \`build-and-push\` + \`scan-image\` (+ \`update-tag\`). Trivy ya terminó cuando se borra → no race.
- Subo \`min-versions-to-keep\` de 5 a 15 (multi-arch usa 3 versions por push → 15 retiene ~5 builds vs ~1.6 antes).
- Aplico el mismo restructure a \`build-qa.yml\` para que el bug no salga en QA cuando empecemos a correrlo.
- \`CLAUDE.md\`: nota explicando el porqué del orden, para que nadie reintroduzca cleanup intermedio.

### Notas

- Tras merge, el siguiente push a develop debería correr completo: build-and-push → scan-image (Trivy verde si las CVEs no han cambiado) → update-tag → cleanup-old-versions.
- Si la imagen actual de dev sigue teniendo CVEs HIGH/CRITICAL fixables que arrastran, Trivy fallará por contenido, no por race. En ese caso abriríamos otro PR con \`.trivyignore\` mientras Dependabot sube las deps.

## Test plan

- [ ] CI verde en este PR (lint backend, lint frontend, test backend, build frontend, gitleaks).
- [ ] Tras merge: el siguiente \`Build & Push Dev Image\` corre los 4 jobs en orden, ninguno con \`MANIFEST_UNKNOWN\`.
- [ ] \`gh run view <id> --log\` muestra el orden: build → scan → update-tag → cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)