### PR TITLE
feat(security): refuse CORS_ORIGINS=* with auth enabled (#63 Sprint 2a)

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -34,7 +34,28 @@ KEYCLOAK_FRONTEND_CLIENT_ID: str = os.environ.get("KEYCLOAK_FRONTEND_CLIENT_ID",
 PORT: int = int(os.environ.get("PORT", "8000"))
 HOST: str = os.environ.get("HOST", "0.0.0.0")
 LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "info")
-CORS_ORIGINS: list[str] = [o.strip() for o in os.environ.get("CORS_ORIGINS", "*").split(",") if o.strip()]
+
+
+def _resolve_cors_origins(raw: str, auth_enabled: bool) -> list[str]:
+    """Parse CORS_ORIGINS and refuse the wildcard when auth is real.
+
+    The combination ``Access-Control-Allow-Origin: *`` + credentials is also
+    rejected by browsers, but more importantly we don't want to ship that
+    config to a deployment where AUTH_ENABLED=true. Wildcard stays valid for
+    local dev (AUTH_ENABLED=false) so the default zero-config flow still
+    works.
+    """
+    items = [o.strip() for o in raw.split(",") if o.strip()]
+    if items == ["*"] and auth_enabled:
+        raise RuntimeError(
+            "CORS_ORIGINS=* is unsafe when AUTH_ENABLED=true. "
+            "Set CORS_ORIGINS to a comma-separated list of trusted origins "
+            "(e.g. https://tradingtool-dev.liontechsolution.com)."
+        )
+    return items
+
+
+CORS_ORIGINS: list[str] = _resolve_cors_origins(os.environ.get("CORS_ORIGINS", "*"), AUTH_ENABLED)
 
 PUBLIC_BASE_URL: str = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
 

--- a/helm/env/dev.yaml
+++ b/helm/env/dev.yaml
@@ -6,7 +6,7 @@ namespace:
 config:
   LOG_LEVEL: "debug"
   AUTH_ENABLED: "true"
-  CORS_ORIGINS: "*"
+  CORS_ORIGINS: "https://tradingtool-dev.liontechsolution.com"
 existingSecret: "tradingtools-secret-dev"
 cloudflareTunnel:
   enabled: true

--- a/helm/env/qa.yaml
+++ b/helm/env/qa.yaml
@@ -6,7 +6,7 @@ namespace:
 config:
   LOG_LEVEL: "info"
   AUTH_ENABLED: "true"
-  CORS_ORIGINS: "*"
+  CORS_ORIGINS: "https://tradingtool-qa.liontechsolution.com"
   KEYCLOAK_REALM: "tradingtool-qa"
 existingSecret: "tradingtools-secret-qa"
 cloudflareTunnel:

--- a/tests/test_config_cors.py
+++ b/tests/test_config_cors.py
@@ -1,0 +1,52 @@
+"""Unit tests for backend.config._resolve_cors_origins."""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.config import _resolve_cors_origins
+
+
+class TestWildcardWithAuth:
+    def test_wildcard_with_auth_enabled_raises(self):
+        with pytest.raises(RuntimeError, match="CORS_ORIGINS=\\* is unsafe"):
+            _resolve_cors_origins("*", auth_enabled=True)
+
+    def test_wildcard_with_auth_disabled_allowed(self):
+        assert _resolve_cors_origins("*", auth_enabled=False) == ["*"]
+
+
+class TestExplicitOrigins:
+    def test_single_origin_with_auth(self):
+        result = _resolve_cors_origins("https://app.example.com", auth_enabled=True)
+        assert result == ["https://app.example.com"]
+
+    def test_multi_origin_with_auth(self):
+        result = _resolve_cors_origins(
+            "https://app.example.com,https://qa.example.com",
+            auth_enabled=True,
+        )
+        assert result == ["https://app.example.com", "https://qa.example.com"]
+
+    def test_strips_whitespace_and_drops_empties(self):
+        result = _resolve_cors_origins(
+            "  https://a.example.com , , https://b.example.com  ",
+            auth_enabled=True,
+        )
+        assert result == ["https://a.example.com", "https://b.example.com"]
+
+
+class TestEdgeCases:
+    def test_empty_string_returns_empty(self):
+        assert _resolve_cors_origins("", auth_enabled=True) == []
+
+    def test_only_commas_returns_empty(self):
+        assert _resolve_cors_origins(",,,", auth_enabled=True) == []
+
+    def test_wildcard_among_others_is_not_rejected(self):
+        # `*` only triggers the safety check when it's the only origin —
+        # mixing it in a list is unusual but not handled here (the developer
+        # asked for it explicitly).
+        result = _resolve_cors_origins("*,https://app.example.com", auth_enabled=True)
+        assert "*" in result
+        assert "https://app.example.com" in result


### PR DESCRIPTION
## Summary

Sprint 2a del [roadmap cross-cutting](https://github.com/open-liontechsolution/tradingtool/issues/63). Primera PR de security hardening operativo, llega ahora que QA está activo (#62) y podemos validar el cambio ahí antes de pasar a dev/prod.

\`Access-Control-Allow-Origin: *\` con \`allow_credentials=True\` lo rechazan los browsers por spec — pero el backend hoy lo declara igual y nadie se entera hasta que un cliente nuevo lo intenta. Mejor que el pod falle al arrancar con un mensaje claro que shippear esa configuración silenciosamente.

## Cambios

- \`backend/config.py\`: extrae el parseo a \`_resolve_cors_origins(raw, auth_enabled)\` y levanta \`RuntimeError\` cuando \`raw='*'\` y \`auth_enabled=True\`. Wildcard sigue válido para dev local con \`AUTH_ENABLED=false\`.
- \`tests/test_config_cors.py\`: 8 tests (wildcard con/sin auth, origins explícitos, strip de whitespace, edge cases).
- \`helm/env/dev.yaml\` y \`helm/env/qa.yaml\`: \`CORS_ORIGINS\` pasa de \`'*'\` a la URL pública del entorno.
- Cualquier nuevo entorno futuro (prod) tendrá que declarar su origen explícitamente o el pod no arranca — exactamente lo que queremos.

## Test plan

- [x] \`pytest tests/test_config_cors.py -v\` → 8/8 passed.
- [x] \`pytest -q\` → 215/215 passed (no regresiones).
- [x] \`ruff check\` clean, \`ruff format --check\` clean.
- [ ] Tras merge: deploy en dev/qa. \`curl -H 'Origin: https://evil.example.com' -I https://tradingtool-{dev,qa}.liontechsolution.com/api/auth/config\` → no devuelve \`Access-Control-Allow-Origin\` (= browser bloquea XHR cross-origin desde origen no autorizado). El frontend en \`tradingtool-{dev,qa}.liontechsolution.com\` sigue funcionando porque su origen está en la lista.
- [ ] Si alguien borra \`CORS_ORIGINS\` del helm values y deja AUTH_ENABLED=true, el pod debería fallar con el RuntimeError claro al arrancar.

## Out of scope (siguientes PRs de Sprint 2)

- Cross-user authorization tests (\`tests/test_authz.py\`): user A intenta GET/PATCH/DELETE de configs/sim_trades de user B → 404/403.
- Rate limiting middleware (\`slowapi\` o \`fastapi-limiter\`).
- Security headers middleware (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS).
- JWKS TTL explícito en \`PyJWKClient\`.
- Comentarios \`# SAFE: ...\` en los 4 sitios SQL f-string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)