### PR TITLE
feat(security): baseline response headers + SAFE comments on SQL f-strings (#63 Sprint 2c)

### DIFF
--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -208,6 +208,9 @@ async def patch_signal_config(
     values.append(user.id)
 
     async with get_db() as db:
+        # SAFE: `fields` entries are appended above from a closed set of
+        # literals derived from the SignalConfigPatch Pydantic model fields,
+        # not from user input. Values bind through the placeholders.
         cursor = await db.execute(
             f"UPDATE signal_configs SET {', '.join(fields)} WHERE id = ? AND user_id = ?",
             values,
@@ -715,6 +718,9 @@ async def patch_real_trade(
     values.append(trade_id)
 
     async with get_db() as db:
+        # SAFE: `fields` entries are appended above from a closed set of
+        # literals derived from the RealTradePatch Pydantic model fields,
+        # not from user input. Values bind through the placeholders.
         cursor = await db.execute(
             f"UPDATE real_trades SET {', '.join(fields)} WHERE id = ?",
             values,

--- a/backend/app.py
+++ b/backend/app.py
@@ -77,6 +77,28 @@ app.add_middleware(
 )
 
 
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    """Attach baseline security headers to every response.
+
+    CSP is intentionally NOT included here yet — it needs end-to-end
+    validation in QA against the OIDC/silent-renew iframe and the
+    Google Fonts loaded by index.css before we enforce. Tracked
+    separately. The four headers below are safe-by-construction
+    (no allowlist tuning needed) and add immediate value.
+    """
+    response = await call_next(request)
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    # HSTS only takes effect over HTTPS, browsers ignore it on http://.
+    response.headers.setdefault(
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains",
+    )
+    return response
+
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     body = await request.body()

--- a/backend/download_engine.py
+++ b/backend/download_engine.py
@@ -117,6 +117,10 @@ async def _upsert_candles(db: aiosqlite.Connection, candles: list[dict]) -> int:
         cols = ", ".join(_KLINE_COLS)
         placeholders = ", ".join("?" for _ in _KLINE_COLS)
         conflict_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in _KLINE_UPDATE_COLS)
+        # SAFE: cols, placeholders and conflict_set are derived from
+        # _KLINE_COLS / _KLINE_UPDATE_COLS, both module-level constants
+        # with hardcoded column names — no user input flows into the SQL
+        # string. Row values still go through the parameter binding below.
         query = (
             f"INSERT INTO klines ({cols}) VALUES ({placeholders}) "
             f"ON CONFLICT (symbol, interval, open_time) DO UPDATE SET {conflict_set}"
@@ -183,6 +187,9 @@ async def _update_job(
         values.append(gaps_found)
 
     values.append(job_id)
+    # SAFE: `fields` entries are appended above from a closed set of literals
+    # ("status=?", "candles_downloaded=?", ...). No user input flows into the
+    # SQL fragment — only the values are bound through the placeholder list.
     await db.execute(f"UPDATE download_jobs SET {', '.join(fields)} WHERE id=?", values)
     await db.commit()
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,83 @@
+"""Tests for the security_headers middleware in backend.app.
+
+Verifies the four baseline headers are attached to every response, both for
+API endpoints (e.g. /api/auth/config) and for arbitrary paths handled by
+FastAPI (e.g. a 404). CSP is intentionally not asserted yet — it lives in
+a follow-up once we validate it end-to-end against OIDC in QA.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_db(tmp_path):
+    db_path = str(tmp_path / "test_headers.db")
+    os.environ["DB_PATH"] = db_path
+    import backend.database as dbmod
+
+    dbmod.DB_PATH = __import__("pathlib").Path(db_path)
+    yield
+
+
+def _build_app() -> FastAPI:
+    """Mount only the security_headers middleware on a tiny app."""
+    from backend.app import security_headers
+
+    app = FastAPI()
+    app.middleware("http")(security_headers)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_headers_present_on_200():
+    client = TestClient(_build_app())
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert "max-age=31536000" in resp.headers["Strict-Transport-Security"]
+    assert "includeSubDomains" in resp.headers["Strict-Transport-Security"]
+
+
+def test_headers_present_on_404():
+    """Even FastAPI's auto-404 should carry the headers (middleware always runs)."""
+    client = TestClient(_build_app())
+    resp = client.get("/nonexistent")
+    assert resp.status_code == 404
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_existing_header_is_not_overwritten():
+    """`setdefault` semantics: a downstream handler can override these
+    if it has a real reason to (the test docs the contract)."""
+    from backend.app import security_headers
+
+    app = FastAPI()
+    app.middleware("http")(security_headers)
+
+    @app.get("/embed-allowed")
+    async def embed_allowed():
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            content={"ok": True},
+            headers={"X-Frame-Options": "SAMEORIGIN"},
+        )
+
+    client = TestClient(app)
+    resp = client.get("/embed-allowed")
+    assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
+    # The other defaults still apply.
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary

Sprint 2c del [roadmap](https://github.com/open-liontechsolution/tradingtool/issues/63). Tres ejes pequeños del audit P2 que cabían juntos.

### 1. Security headers middleware
\`backend/app.py\` ahora monta un middleware HTTP que añade en toda respuesta:

- \`X-Frame-Options: DENY\` — clickjacking.
- \`X-Content-Type-Options: nosniff\` — MIME sniffing.
- \`Referrer-Policy: strict-origin-when-cross-origin\` — fuga de URLs internas.
- \`Strict-Transport-Security: max-age=31536000; includeSubDomains\` — HSTS.

Usa \`setdefault\` para que un handler downstream pueda sobrescribirlos si tiene razón explícita (ej. una vista que sí debe permitir embedding).

**CSP NO entra aquí** — necesita validación end-to-end con el iframe OIDC de \`oidc-client-ts\` (silent renew) y Google Fonts (cargados en \`index.css\`) en QA antes de enforcar. Si lo metiera ahora rompería login. Lo dejo como follow-up tras validar.

### 2. Tests del middleware
\`tests/test_security_headers.py\` (3 tests):
- Presencia en 200.
- Presencia en 404 (middleware corre incluso en respuestas auto-generadas).
- Semántica \`setdefault\`: handler que ya pone \`X-Frame-Options: SAMEORIGIN\` no es pisado.

### 3. \`# SAFE: ...\` comments en SQL f-strings
4 sitios identificados en el audit, todos con columnas hardcoded (sin user input):
- \`download_engine.py:121-123\` — INSERT klines (cols/placeholders desde \`_KLINE_COLS\`).
- \`download_engine.py:188\` — UPDATE download_jobs (fields desde literal).
- \`signal_routes.py:212\` — PATCH signal_configs (fields desde Pydantic \`SignalConfigPatch\`).
- \`signal_routes.py:721\` — PATCH real_trades (fields desde Pydantic \`RealTradePatch\`).

El comentario documenta el invariante: si alguien refactoriza y empieza a añadir field names desde un dict del request, ya hay una pista visible en el sitio para parar.

### JWKS TTL — no-op
El audit listaba "JWKS sin invalidación explícita". Mirando \`backend/auth.py\`:
\`\`\`python
_JWKS_CACHE_SECONDS = 300
_jwks_client = PyJWKClient(jwks_url, cache_jwk_set=True, lifespan=_JWKS_CACHE_SECONDS)
\`\`\`
Ya está explícito (5 min). Lo cierro como done en el comentario de #63 sin tocarlo.

## Test plan

- [x] \`pytest tests/test_security_headers.py -v\` → 3/3 passed.
- [x] \`pytest -q\` → 233/233 passed (230 pre + 3 nuevos).
- [x] \`ruff check backend/ tests/\` clean, \`ruff format --check\` clean.
- [ ] Tras merge a dev/qa: \`curl -I https://tradingtool-{dev,qa}.liontechsolution.com/api/auth/config\` muestra los 4 headers.
- [ ] Browser dev tools: las response headers de un GET arbitrario incluyen los 4.

## Out of scope (siguientes PRs de Sprint 2)

- **CSP**: necesita probar con el flujo OIDC + Google Fonts. Voy a abrir un PR con \`Content-Security-Policy-Report-Only\` primero, ver violations en logs durante un par de días, y luego enforcar.
- **Rate limiting**: middleware (\`slowapi\` o \`fastapi-limiter\`), añade una dependencia y configuración por endpoint, mejor en su propio PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)