### PR TITLE
feat(security): rate limiting middleware via slowapi (#63 Sprint 2d)

### DIFF
--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -208,6 +208,9 @@ async def patch_signal_config(
     values.append(user.id)
 
     async with get_db() as db:
+        # SAFE: `fields` entries are appended above from a closed set of
+        # literals derived from the SignalConfigPatch Pydantic model fields,
+        # not from user input. Values bind through the placeholders.
         cursor = await db.execute(
             f"UPDATE signal_configs SET {', '.join(fields)} WHERE id = ? AND user_id = ?",
             values,
@@ -715,6 +718,9 @@ async def patch_real_trade(
     values.append(trade_id)
 
     async with get_db() as db:
+        # SAFE: `fields` entries are appended above from a closed set of
+        # literals derived from the RealTradePatch Pydantic model fields,
+        # not from user input. Values bind through the placeholders.
         cursor = await db.execute(
             f"UPDATE real_trades SET {', '.join(fields)} WHERE id = ?",
             values,

--- a/backend/app.py
+++ b/backend/app.py
@@ -77,6 +77,28 @@ app.add_middleware(
 )
 
 
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    """Attach baseline security headers to every response.
+
+    CSP is intentionally NOT included here yet — it needs end-to-end
+    validation in QA against the OIDC/silent-renew iframe and the
+    Google Fonts loaded by index.css before we enforce. Tracked
+    separately. The four headers below are safe-by-construction
+    (no allowlist tuning needed) and add immediate value.
+    """
+    response = await call_next(request)
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+    # HSTS only takes effect over HTTPS, browsers ignore it on http://.
+    response.headers.setdefault(
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains",
+    )
+    return response
+
+
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     body = await request.body()

--- a/backend/app.py
+++ b/backend/app.py
@@ -13,6 +13,9 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from starlette.responses import Response
 
 from backend.api.backtest_routes import router as backtest_router
@@ -34,6 +37,7 @@ from backend.config import (
 )
 from backend.database import get_db, init_db
 from backend.live_tracker import run_live_tracker
+from backend.rate_limit import limiter
 from backend.signal_engine import run_signal_scanner
 from backend.telegram_client import set_webhook as telegram_set_webhook
 
@@ -67,6 +71,13 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan,
 )
+
+# Rate limiting — `application_limits` (set in backend.rate_limit) caps every
+# request per-client at 60/min by default. The middleware short-circuits with
+# a 429 when the bucket is exhausted; the handler renders a clean JSON body.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/download_engine.py
+++ b/backend/download_engine.py
@@ -117,6 +117,10 @@ async def _upsert_candles(db: aiosqlite.Connection, candles: list[dict]) -> int:
         cols = ", ".join(_KLINE_COLS)
         placeholders = ", ".join("?" for _ in _KLINE_COLS)
         conflict_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in _KLINE_UPDATE_COLS)
+        # SAFE: cols, placeholders and conflict_set are derived from
+        # _KLINE_COLS / _KLINE_UPDATE_COLS, both module-level constants
+        # with hardcoded column names — no user input flows into the SQL
+        # string. Row values still go through the parameter binding below.
         query = (
             f"INSERT INTO klines ({cols}) VALUES ({placeholders}) "
             f"ON CONFLICT (symbol, interval, open_time) DO UPDATE SET {conflict_set}"
@@ -183,6 +187,9 @@ async def _update_job(
         values.append(gaps_found)
 
     values.append(job_id)
+    # SAFE: `fields` entries are appended above from a closed set of literals
+    # ("status=?", "candles_downloaded=?", ...). No user input flows into the
+    # SQL fragment — only the values are bound through the placeholder list.
     await db.execute(f"UPDATE download_jobs SET {', '.join(fields)} WHERE id=?", values)
     await db.commit()
 

--- a/backend/rate_limit.py
+++ b/backend/rate_limit.py
@@ -1,0 +1,52 @@
+"""Rate-limiting plumbing — single ``Limiter`` shared by app + route modules.
+
+This module exists separately from ``backend.app`` so route handlers can
+import the limiter without forming an import cycle (``app.py`` imports
+the routers, the routers can't import back into ``app.py``).
+
+Defaults can be overridden at deploy time via env vars:
+
+- ``RATE_LIMIT_DEFAULT`` (default ``"60/minute"``): per-client global cap.
+- ``RATE_LIMIT_ENABLED`` (default ``"true"``): hard kill-switch — set to
+  ``"false"`` in test environments where 429s would mask real failures.
+
+The key function prefers the actual client IP propagated by Cloudflare /
+upstream proxies (``cf-connecting-ip``, then the first hop of
+``x-forwarded-for``) over ``request.client.host``, which behind the
+Cloudflare Tunnel sidecar is always the cloudflared peer and would
+collapse all traffic into a single bucket.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import Request
+from slowapi import Limiter
+
+_DEFAULT_LIMIT = os.environ.get("RATE_LIMIT_DEFAULT", "60/minute")
+_ENABLED = os.environ.get("RATE_LIMIT_ENABLED", "true").lower() in ("1", "true", "yes")
+
+
+def client_key(request: Request) -> str:
+    """Return the rate-limit bucket key for ``request``.
+
+    Order of preference: ``cf-connecting-ip`` → first hop of
+    ``x-forwarded-for`` → ``request.client.host`` → ``"unknown"``.
+    """
+    cf_ip = request.headers.get("cf-connecting-ip")
+    if cf_ip:
+        return cf_ip.strip()
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else "unknown"
+
+
+limiter = Limiter(
+    key_func=client_key,
+    application_limits=[_DEFAULT_LIMIT],
+    enabled=_ENABLED,
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ numpy>=1.26.0
 pydantic>=2.7.0
 PyJWT>=2.8.0
 cryptography>=42.0.0
+slowapi>=0.1.9

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,105 @@
+"""Tests for backend.rate_limit + the SlowAPI integration in backend.app.
+
+The production limiter pulls its config from env at import time, so each
+test builds a fresh ``Limiter`` with a tight per-test limit, mounts the
+SlowAPI middleware on a minimal app, and exercises 200 → 200 → 429.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+
+from backend.rate_limit import client_key
+
+
+def _build_app(limit: str, *, enabled: bool = True) -> FastAPI:
+    """Build a minimal FastAPI with a fresh Limiter applying ``limit``."""
+    limiter = Limiter(
+        key_func=client_key,
+        application_limits=[limit],
+        enabled=enabled,
+    )
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_under_limit_returns_200():
+    client = TestClient(_build_app("3/minute"))
+    for _ in range(3):
+        resp = client.get("/ping")
+        assert resp.status_code == 200
+
+
+def test_over_limit_returns_429():
+    client = TestClient(_build_app("2/minute"))
+    assert client.get("/ping").status_code == 200
+    assert client.get("/ping").status_code == 200
+    resp = client.get("/ping")
+    assert resp.status_code == 429
+    body = resp.text.lower()
+    # SlowAPI's default handler returns a body that mentions the limit.
+    assert "rate limit" in body or "ratelimit" in body or "2 per" in body
+
+
+def test_disabled_limiter_lets_everything_through():
+    client = TestClient(_build_app("1/minute", enabled=False))
+    for _ in range(5):
+        assert client.get("/ping").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# client_key — bucket selection prefers the actual client, not the proxy peer
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal stand-in for fastapi.Request shaped just enough for client_key."""
+
+    def __init__(self, headers: dict[str, str], client_host: str | None = "127.0.0.1"):
+        self.headers = headers
+
+        class _C:
+            host = client_host
+
+        self.client = _C() if client_host is not None else None
+
+
+def test_client_key_prefers_cf_connecting_ip():
+    req = _FakeRequest(
+        headers={"cf-connecting-ip": "203.0.113.1", "x-forwarded-for": "10.0.0.1"},
+    )
+    assert client_key(req) == "203.0.113.1"
+
+
+def test_client_key_falls_back_to_xff_first_hop():
+    req = _FakeRequest(
+        headers={"x-forwarded-for": "203.0.113.2, 10.0.0.1, 192.168.1.1"},
+    )
+    assert client_key(req) == "203.0.113.2"
+
+
+def test_client_key_falls_back_to_request_client_host():
+    req = _FakeRequest(headers={}, client_host="198.51.100.1")
+    assert client_key(req) == "198.51.100.1"
+
+
+def test_client_key_returns_unknown_when_no_source():
+    req = _FakeRequest(headers={}, client_host=None)
+    assert client_key(req) == "unknown"
+
+
+def test_client_key_strips_whitespace_in_xff():
+    req = _FakeRequest(headers={"x-forwarded-for": "   203.0.113.3   "})
+    assert client_key(req) == "203.0.113.3"

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,0 +1,83 @@
+"""Tests for the security_headers middleware in backend.app.
+
+Verifies the four baseline headers are attached to every response, both for
+API endpoints (e.g. /api/auth/config) and for arbitrary paths handled by
+FastAPI (e.g. a 404). CSP is intentionally not asserted yet — it lives in
+a follow-up once we validate it end-to-end against OIDC in QA.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _use_temp_db(tmp_path):
+    db_path = str(tmp_path / "test_headers.db")
+    os.environ["DB_PATH"] = db_path
+    import backend.database as dbmod
+
+    dbmod.DB_PATH = __import__("pathlib").Path(db_path)
+    yield
+
+
+def _build_app() -> FastAPI:
+    """Mount only the security_headers middleware on a tiny app."""
+    from backend.app import security_headers
+
+    app = FastAPI()
+    app.middleware("http")(security_headers)
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return app
+
+
+def test_headers_present_on_200():
+    client = TestClient(_build_app())
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+    assert resp.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert "max-age=31536000" in resp.headers["Strict-Transport-Security"]
+    assert "includeSubDomains" in resp.headers["Strict-Transport-Security"]
+
+
+def test_headers_present_on_404():
+    """Even FastAPI's auto-404 should carry the headers (middleware always runs)."""
+    client = TestClient(_build_app())
+    resp = client.get("/nonexistent")
+    assert resp.status_code == 404
+    assert resp.headers["X-Frame-Options"] == "DENY"
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_existing_header_is_not_overwritten():
+    """`setdefault` semantics: a downstream handler can override these
+    if it has a real reason to (the test docs the contract)."""
+    from backend.app import security_headers
+
+    app = FastAPI()
+    app.middleware("http")(security_headers)
+
+    @app.get("/embed-allowed")
+    async def embed_allowed():
+        from fastapi.responses import JSONResponse
+
+        return JSONResponse(
+            content={"ok": True},
+            headers={"X-Frame-Options": "SAMEORIGIN"},
+        )
+
+    client = TestClient(app)
+    resp = client.get("/embed-allowed")
+    assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
+    # The other defaults still apply.
+    assert resp.headers["X-Content-Type-Options"] == "nosniff"


### PR DESCRIPTION
## Summary

Cierra el último bullet operativo del Sprint 2 del [roadmap](https://github.com/open-liontechsolution/tradingtool/issues/63): rate limiting global por cliente.

### Cambios

- \`backend/rate_limit.py\` (nuevo): \`Limiter\` centralizado con \`key_func\` que prefiere \`cf-connecting-ip\` y \`x-forwarded-for\` sobre \`request.client.host\` — necesario porque detrás del Cloudflare Tunnel sidecar el \`request.client.host\` es siempre el peer del cloudflared, lo que colapsaría a todos los usuarios en un único bucket. Default cap **60/minute** por cliente. Configurable por env (\`RATE_LIMIT_DEFAULT\`, \`RATE_LIMIT_ENABLED\`).
- \`backend/app.py\`: monta \`SlowAPIMiddleware\` + handler 429 estándar de slowapi (\`_rate_limit_exceeded_handler\`).
- \`requirements.txt\`: añade \`slowapi>=0.1.9\`.
- \`tests/test_rate_limit.py\` (8 tests):
  - under/over limit (200 → 200 → 429),
  - kill-switch \`enabled=False\` deja todo pasar,
  - los 5 caminos del \`key_func\` (cf-connecting-ip, xff first hop, client.host, missing client, whitespace).

### ¿Por qué \`application_limits\` y no decoradores?
Por simplicidad: el plan original mencionaba 60/min default + 10/min en endpoints de creación. El cap global ya cierra el peor caso (mass-create de configs/real_trades). Decoradores per-endpoint requieren añadir \`request: Request\` a cada signature, y sin datos reales de uso es prematuro afinar. Si más adelante vemos abuso en un endpoint específico, lo añadimos.

### Configuración por entorno
La default 60/min es la del audit. Si en algún momento queremos relajar/apretar:
\`\`\`yaml
# helm/env/<env>.yaml
config:
  RATE_LIMIT_DEFAULT: "120/minute"
  # RATE_LIMIT_ENABLED: "false"  # solo si hay que apagar de emergencia
\`\`\`

## Test plan

- [x] \`pytest tests/test_rate_limit.py -v\` → 8/8 passed.
- [x] \`pytest -q\` → 241/241 passed (233 pre + 8 nuevos).
- [x] \`ruff check backend/ tests/\` clean.
- [ ] Tras merge a dev/qa: 61ª request en 1 min al mismo endpoint desde la misma IP → 429.
- [ ] Comportamiento con Cloudflare Tunnel: requests llegan con \`cf-connecting-ip\` distinto por usuario → buckets separados (no colapso).

## Out of scope

- Per-endpoint stricter limits (\`@limiter.limit("10/minute")\` en POST configs/reset-equity/real-trades). Bloquea cambios en signatures de routes — añadir solo si datos reales de tráfico lo demandan.
- Storage compartido entre pods (Redis, Memcached). Para 1 réplica el in-memory de slowapi vale; cuando escalemos horizontal habrá que migrar.
- CSP (otro PR pendiente, requiere validación QA con OIDC iframe + Google Fonts antes de enforcar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)