### PR TITLE
feat(security): CSP in Report-Only mode + /api/csp-report endpoint (#63)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -88,15 +88,53 @@ app.add_middleware(
 )
 
 
+def _build_csp(keycloak_url: str) -> str | None:
+    """Build the Content-Security-Policy string for a given Keycloak URL.
+
+    Returns ``None`` when ``keycloak_url`` is empty — that's the local-dev
+    path with ``AUTH_ENABLED=false`` where a CSP referencing an empty
+    hostname would be invalid. In that mode there is no auth iframe to
+    allow anyway, so the other security headers are enough.
+
+    Notes on the chosen sources:
+
+    * ``style-src 'unsafe-inline'`` is regrettable but Recharts /
+      lightweight-charts both inject inline styles. Can be tightened
+      after migrating those to nonces.
+    * ``connect-src`` and ``frame-src`` allow the Keycloak host so that
+      ``oidc-client-ts`` can fetch the token endpoint, JWKS, and run
+      the silent-renew iframe.
+    * Stays in Report-Only mode initially so we can observe violations
+      via ``/api/csp-report`` without breaking the SPA. Promote to
+      enforcement (``Content-Security-Policy``) once the report log is
+      quiet for a few days.
+    """
+    if not keycloak_url:
+        return None
+    return (
+        "default-src 'self'; "
+        "script-src 'self'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "img-src 'self' data:; "
+        f"connect-src 'self' {keycloak_url}; "
+        f"frame-src {keycloak_url}; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self'; "
+        "form-action 'self'; "
+        "report-uri /api/csp-report"
+    )
+
+
+_CSP_REPORT_ONLY = _build_csp(KEYCLOAK_URL)
+
+
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     """Attach baseline security headers to every response.
 
-    CSP is intentionally NOT included here yet — it needs end-to-end
-    validation in QA against the OIDC/silent-renew iframe and the
-    Google Fonts loaded by index.css before we enforce. Tracked
-    separately. The four headers below are safe-by-construction
-    (no allowlist tuning needed) and add immediate value.
+    CSP runs in Report-Only mode for now — see ``_build_csp`` for the
+    rationale and the rollout plan to switch to enforcement.
     """
     response = await call_next(request)
     response.headers.setdefault("X-Frame-Options", "DENY")
@@ -107,7 +145,26 @@ async def security_headers(request: Request, call_next):
         "Strict-Transport-Security",
         "max-age=31536000; includeSubDomains",
     )
+    if _CSP_REPORT_ONLY is not None:
+        response.headers.setdefault("Content-Security-Policy-Report-Only", _CSP_REPORT_ONLY)
     return response
+
+
+@app.post("/api/csp-report", tags=["security"])
+async def csp_report(request: Request) -> Response:
+    """Receive CSP violation reports from browsers (Report-Only mode).
+
+    Browsers POST one report per blocked resource with
+    ``Content-Type: application/csp-report``. We log a truncated body
+    so the report shows up in pod logs (``kubectl logs ...``) without
+    spamming downstream sinks. Once the policy is stable and we flip
+    to enforcement, this endpoint can either be removed or kept as a
+    failure beacon.
+    """
+    body = await request.body()
+    snippet = body.decode("utf-8", errors="replace")[:1000]
+    logger.warning("CSP violation report: %s", snippet)
+    return Response(status_code=204)
 
 
 @app.exception_handler(RequestValidationError)

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -81,3 +81,48 @@ def test_existing_header_is_not_overwritten():
     assert resp.headers["X-Frame-Options"] == "SAMEORIGIN"
     # The other defaults still apply.
     assert resp.headers["X-Content-Type-Options"] == "nosniff"
+
+
+# ---------------------------------------------------------------------------
+# CSP — pure function tests for _build_csp
+# ---------------------------------------------------------------------------
+
+
+def test_build_csp_returns_none_when_keycloak_url_empty():
+    from backend.app import _build_csp
+
+    assert _build_csp("") is None
+
+
+def test_build_csp_includes_keycloak_url_in_connect_and_frame():
+    from backend.app import _build_csp
+
+    csp = _build_csp("https://keycloak.example.com")
+    assert csp is not None
+    assert "connect-src 'self' https://keycloak.example.com" in csp
+    assert "frame-src https://keycloak.example.com" in csp
+
+
+def test_build_csp_keeps_report_uri_pointing_at_app_endpoint():
+    from backend.app import _build_csp
+
+    csp = _build_csp("https://keycloak.example.com")
+    assert "report-uri /api/csp-report" in csp
+
+
+def test_build_csp_blocks_third_party_default_sources():
+    from backend.app import _build_csp
+
+    csp = _build_csp("https://keycloak.example.com")
+    assert "default-src 'self'" in csp
+    assert "frame-ancestors 'none'" in csp
+    assert "base-uri 'self'" in csp
+    assert "form-action 'self'" in csp
+
+
+def test_build_csp_allows_google_fonts():
+    from backend.app import _build_csp
+
+    csp = _build_csp("https://keycloak.example.com")
+    assert "https://fonts.googleapis.com" in csp
+    assert "https://fonts.gstatic.com" in csp


### PR DESCRIPTION
## Summary

Cierra el último ítem de Sprint 2 que quedaba pendiente: Content-Security-Policy. Lo meto en **Report-Only** primero (no rompe el SPA si la policy está mal calibrada) + un endpoint que loggea violaciones para iterar.

## Cambios

### \`backend/app.py\`
- \`_build_csp(keycloak_url)\`: función pura que devuelve el string del header o \`None\` cuando \`keycloak_url\` está vacío (modo dev local con \`AUTH_ENABLED=false\`).
- Política inicial:
  - \`default-src 'self'\` + \`base-uri 'self'\` + \`form-action 'self'\` + \`frame-ancestors 'none'\`.
  - \`script-src 'self'\` (sin \`unsafe-inline\`).
  - \`style-src 'self' 'unsafe-inline' https://fonts.googleapis.com\` — el \`unsafe-inline\` es porque Recharts y lightweight-charts inyectan estilos inline. Apretar a nonces requiere refactor en otro PR.
  - \`font-src 'self' https://fonts.gstatic.com\` — Google Fonts CDN.
  - \`img-src 'self' data:\` — data URIs para SVGs inline.
  - \`connect-src 'self' <KEYCLOAK_URL>\` y \`frame-src <KEYCLOAK_URL>\` — \`oidc-client-ts\` necesita XHR a /token y JWKS, y un iframe para el silent renew.
  - \`report-uri /api/csp-report\`.
- \`POST /api/csp-report\`: recibe los reports del browser, loggea con truncado a 1000 chars, devuelve 204. Sin auth (los browsers no se pueden autenticar a este endpoint).
- El middleware \`security_headers\` solo añade el header si \`_CSP_REPORT_ONLY\` no es \`None\`.

### \`tests/test_security_headers.py\`
5 tests nuevos para \`_build_csp\` como función pura:
- empty URL → None.
- conexión y frame autorizan la URL de Keycloak real.
- \`report-uri /api/csp-report\` presente.
- defaults restrictivos (\`default-src 'self'\`, \`frame-ancestors 'none'\`, ...).
- Google Fonts permitidos.

## Plan de rollout

1. Merge → deploy automático a dev (Argo manual) y QA (Argo automático).
2. Cargar la SPA en \`tradingtool-{dev,qa}.liontechsolution.com\`, hacer login OIDC, navegar todos los tabs (Data Manager, Backtest, Signals, Profile).
3. \`kubectl logs -n tradingtool-{dev,qa} -l app.kubernetes.io/name=tradingtools | grep "CSP violation"\` durante un par de días.
4. Iterar la policy hasta logs limpios — añadir lo que falte (probablemente algún CDN o data URI extra que no anticipé).
5. Otro PR pequeño cambia \`Content-Security-Policy-Report-Only\` → \`Content-Security-Policy\` (enforcing). Documentado en CLAUDE.md el cambio de nombre.

## Test plan

- [x] \`pytest tests/test_security_headers.py -v\` → 8/8 passed.
- [x] \`pytest -q\` → 246/246 passed.
- [x] \`ruff check\` clean.
- [ ] Tras merge: \`curl -I https://tradingtool-{dev,qa}.liontechsolution.com/api/auth/config\` muestra el header \`Content-Security-Policy-Report-Only\`.
- [ ] DevTools: cargar la SPA → ver violations en la consola (esperado mientras Report-Only) y confirmar que la app sigue funcional.
- [ ] \`POST /api/csp-report\` con un body fake → 204 + log "CSP violation report: ...".

## Out of scope

- Promote a enforcing — siguiente PR tras observar.
- Tightening de \`style-src\` (eliminar \`'unsafe-inline'\` requiere migrar a nonces los estilos de Recharts / lightweight-charts).
- \`report-to\` (Reports API moderno) — \`report-uri\` legacy es suficiente para todos los browsers actuales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)