### PR TITLE
ops(security): pod + container securityContext hardening (#78)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -14,10 +14,14 @@ spec:
       labels:
         {{- include "tradingtools.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           ports:
             - name: http
               containerPort: 8000
@@ -45,10 +49,17 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: data
+              mountPath: /app/data
         {{- if .Values.cloudflareTunnel.enabled }}
         - name: cloudflared
           image: "{{ .Values.cloudflareTunnel.image.repository }}:{{ .Values.cloudflareTunnel.image.tag }}"
           imagePullPolicy: {{ .Values.cloudflareTunnel.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.cloudflareTunnel.securityContext | nindent 12 }}
           args:
             - tunnel
             - --no-autoupdate
@@ -64,3 +75,8 @@ spec:
           resources:
             {{- toYaml .Values.cloudflareTunnel.resources | nindent 12 }}
         {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: data
+          emptyDir: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,29 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# Pod-level security context applied to every container. Per-container
+# overrides live below in `securityContext` (app) and
+# `cloudflareTunnel.securityContext` (sidecar). See #78.
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
+
+# App container security context (Pod Security Standards: restricted).
+# `readOnlyRootFilesystem: true` requires emptyDir mounts for the writable
+# paths the app touches at runtime — `/tmp` (Python/uvicorn) and
+# `/app/data` (defensive: only used if SQLite, never in dev/qa where
+# DATABASE_URL is set, but keeps the mkdir in init_db() safe).
+securityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
 service:
   type: ClusterIP
   port: 8000
@@ -66,6 +89,20 @@ cloudflareTunnel:
     limits:
       cpu: 200m
       memory: 128Mi
+  # Sidecar security context. The cloudflare/cloudflared image runs as the
+  # `nonroot` user (uid 65532); pinning the uid explicitly so kubelet can
+  # validate `runAsNonRoot: true` (set at pod level) without resolving the
+  # symbolic name from /etc/passwd inside the image.
+  # `readOnlyRootFilesystem` is intentionally NOT set yet — cloudflared in
+  # token mode buffers small connection state to disk; add it as a follow-up
+  # once we've validated under load.
+  securityContext:
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 ingress:
   enabled: false


### PR DESCRIPTION
Closes #78.

## Summary

Brings the Deployment up to Pod Security Standards \"restricted\". All values are exposed in \`values.yaml\` so per-env can override; defaults are the hardened ones.

**Pod-level** (\`podSecurityContext\`):
- \`runAsNonRoot: true\`
- \`fsGroup: 1001\` (so the emptyDir mounts are writable by the app user/group)
- \`seccompProfile.type: RuntimeDefault\`

**App container** (\`securityContext\`):
- \`runAsUser/runAsGroup: 1001\` (matches the \`appuser\` baked into the Dockerfile)
- \`allowPrivilegeEscalation: false\`
- \`readOnlyRootFilesystem: true\`
- \`capabilities.drop: [ALL]\`

**Cloudflared sidecar** (\`cloudflareTunnel.securityContext\`):
- \`runAsUser/runAsGroup: 65532\` (the image's \`nonroot\` user; pinned numerically so kubelet can validate \`runAsNonRoot\` without resolving symbolic users from /etc/passwd inside the image)
- \`allowPrivilegeEscalation: false\`
- \`capabilities.drop: [ALL]\`

\`readOnlyRootFilesystem\` on cloudflared is **deliberately deferred** to a follow-up: the daemon in \`--token\` mode buffers a small amount of connection state to disk; promote once we've validated under load.

## Writable paths

\`readOnlyRootFilesystem: true\` on the app container needs explicit emptyDir mounts:
- **/tmp** — Python interpreter and uvicorn's transient buffers.
- **/app/data** — defensive. Only used when SQLite is selected; dev/qa always run on Postgres so \`init_db()\` skips that path. But the inline \`DB_PATH.parent.mkdir(...)\` would crash on read-only fs if anyone ever ran the image without \`DATABASE_URL\` set, so the mount keeps that safe.

## Test plan

- [x] \`helm lint helm/\` clean.
- [x] \`helm template tradingtool helm/ -f helm/env/dev.yaml\` renders the expected blocks (verified pod-level, both containers, both emptyDir volumes).
- [x] \`helm template tradingtool helm/ -f helm/env/qa.yaml\` renders the same fields.
- [ ] Post-merge in dev: rollout completes 2/2, \`/healthz\` 200, \`kubectl exec ... -- whoami\` returns appuser (uid 1001), \`touch /foo\` returns \"Read-only file system\".
- [ ] Same checks in qa with the next \`v0.1.x-rcN\` tag (or \`workflow_dispatch\`).

## Rollout safety

Same shape as #86: if anything regresses (e.g. an unexpected write path), the new pod fails readiness, the old pod stays Running, and the rollout blocks rather than going down. Recovery is fast — revert this PR or add the missing emptyDir.

## Out of scope

- AppArmor / SELinux profiles.
- Pod Security Admission namespace label (\`pod-security.kubernetes.io/enforce: restricted\`). With this PR the pods *would* admit under \`restricted\`; the label can flip in a follow-up.
- \`readOnlyRootFilesystem\` on cloudflared (deferred — see Summary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)