### PR TITLE
ci(security): SBOM per build + dependency-review on PRs (#79)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -82,6 +82,34 @@ jobs:
           format: table
           vuln-type: os,library
 
+  generate-sbom:
+    name: Generate SBOM (SPDX JSON)
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    # Non-blocking on failure: SBOM is for auditing, not gating. Trivy
+    # already covers vuln scanning; this captures the full dependency
+    # surface as a workflow artifact for offline review (#79).
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image_digest }}
+          format: spdx-json
+          artifact-name: sbom-dev-${{ needs.build-and-push.outputs.short_sha }}.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
   update-tag:
     name: Update dev image tag for Argo CD
     needs:
@@ -123,6 +151,7 @@ jobs:
     needs:
       - build-and-push
       - scan-image
+      - generate-sbom
       - update-tag
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -110,6 +110,34 @@ jobs:
           format: table
           vuln-type: os,library
 
+  generate-sbom:
+    name: Generate SBOM (SPDX JSON)
+    needs:
+      - resolve-tag
+      - build-and-push
+    runs-on: ubuntu-latest
+    # Non-blocking on failure: SBOM is for auditing, not gating (#79).
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ needs.build-and-push.outputs.image_digest }}
+          format: spdx-json
+          artifact-name: sbom-qa-${{ needs.resolve-tag.outputs.image_tag }}.spdx.json
+          upload-artifact: true
+          upload-release-assets: false
+
   update-tag:
     name: Update qa image tag for Argo CD
     needs:
@@ -265,6 +293,7 @@ jobs:
     needs:
       - build-and-push
       - scan-image
+      - generate-sbom
       - update-tag
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,21 @@ jobs:
           PARITY_SLOTS: slot_a
         run: pytest -m slow tests/integration/test_parity.py -v --tb=short
 
+  dependency-review:
+    name: Dependency review (block CVEs ≥ HIGH)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
   build-frontend:
     name: Build frontend (Vite)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,3 +213,9 @@ Replays a fixed klines fixture through both the backtest engine and the live eng
 - **QA versioning convention**: tags follow `vMAJOR.MINOR.PATCH-rcN`. New major or minor cycle starts at `rc1`; subsequent fixes during the same QA cycle increment the rc (`-rc2`, `-rc3`, ...). When a `-rcN` is validated in QA it gets re-tagged as the prod release (separate workflow when prod exists).
 - **Secrets**: never committed. Live under `helm/secrets/<env>.yaml` (per-env, gitignored). Template at `helm/secrets/example.yaml` (committed). Apply with `kubectl apply -f helm/secrets/<env>.yaml`. Legacy locations (`helm/env/secrets.yaml`, `helm/env/secrets-*.yaml`) stay covered by `.gitignore` for backwards compatibility, but new env manifests should land under `helm/secrets/`.
 - **Postgres provisioning**: the CNPG cluster `platform-postgres-dev` is shared. The dev DB+user were created by hand; the qa DB (`tradingtool-qa`) and user (`tradingtool-qa-user`) are created the same way (one-off `psql` against the superuser, see `argocd/qa-application.yaml` header for the actual SQL).
+
+## Supply chain (post-#79)
+
+- **SBOM per build**: `build-dev.yml` and `build-qa.yml` each include a `generate-sbom` job that runs `anchore/sbom-action` against the freshly pushed image digest and uploads the SPDX-JSON output as a workflow artifact (`sbom-dev-<sha>.spdx.json` / `sbom-qa-<tag>.spdx.json`). Non-blocking on failure — Trivy already gates on CVEs; the SBOM exists for offline auditing. Download from the Actions run page → Artifacts.
+- **Dependency review on PRs**: `ci.yml` has a `dependency-review` job using `actions/dependency-review-action@v4`. Blocks PRs that introduce dependencies with CVEs ≥ HIGH. Posts a comment on the PR when it fails (`comment-summary-in-pr: on-failure`).
+- Out of scope here: `cosign` signing / SLSA provenance, scanning the SBOM against an external vuln DB (Trivy already covers the image surface).


### PR DESCRIPTION
Closes #79.

## Summary

Adds two supply-chain visibility gates without disrupting the existing pipelines.

**SBOM per image build** (`build-dev.yml`, `build-qa.yml`):
- New \`generate-sbom\` job runs \`anchore/sbom-action@v0\` against the freshly pushed image digest and uploads SPDX-JSON as a workflow artifact: \`sbom-dev-<sha>.spdx.json\` / \`sbom-qa-<tag>.spdx.json\`.
- \`continue-on-error: true\` — Trivy already gates on CVEs; the SBOM exists for offline review, not as a blocker.
- \`cleanup-old-versions\` adds \`generate-sbom\` to its \`needs:\` so we never delete the image manifest before sbom-action has read it (same defensive pattern as Trivy).

**Dependency review on PRs** (`ci.yml`):
- New \`dependency-review\` job using \`actions/dependency-review-action@v4\`.
- \`fail-on-severity: high\` blocks PRs that introduce dependencies with CVEs ≥ HIGH.
- \`comment-summary-in-pr: on-failure\` posts a summary to the PR when the gate fires (needs \`pull-requests: write\`, scoped to the job).

**Docs** (`CLAUDE.md`):
- Added a \"Supply chain\" section describing where SBOMs land and how the PR gate works.

## Test plan

- [x] YAML parse of all three workflow files.
- [ ] Post-merge: next \`build-dev\` run produces a downloadable \`sbom-dev-<sha>.spdx.json\` artifact on the run page.
- [ ] Post-merge: open a throwaway PR adding a known-vulnerable dep (e.g. an old \`requests\`) — \`dependency-review\` job fails with a comment on the PR. Close PR without merging.
- [ ] Once smoke runs are stable, drop \`continue-on-error: true\` from \`generate-sbom\` if we want it to gate too.

## Out of scope

- \`cosign sign\` / SLSA provenance attestation.
- External SBOM vuln scanning (Trivy already covers the image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)