### PR TITLE
feat(security): promote CSP from Report-Only to enforcing (#82)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -104,10 +104,11 @@ def _build_csp(keycloak_url: str) -> str | None:
     * ``connect-src`` and ``frame-src`` allow the Keycloak host so that
       ``oidc-client-ts`` can fetch the token endpoint, JWKS, and run
       the silent-renew iframe.
-    * Stays in Report-Only mode initially so we can observe violations
-      via ``/api/csp-report`` without breaking the SPA. Promote to
-      enforcement (``Content-Security-Policy``) once the report log is
-      quiet for a few days.
+    * Header is now sent as ``Content-Security-Policy`` (enforcing) — the
+      previous Report-Only phase ran clean in dev, so violations now
+      block instead of just being reported. The ``report-uri
+      /api/csp-report`` directive stays so future regressions still
+      surface in logs even though they're blocked at runtime.
     """
     if not keycloak_url:
         return None
@@ -126,15 +127,18 @@ def _build_csp(keycloak_url: str) -> str | None:
     )
 
 
-_CSP_REPORT_ONLY = _build_csp(KEYCLOAK_URL)
+_CSP = _build_csp(KEYCLOAK_URL)
 
 
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     """Attach baseline security headers to every response.
 
-    CSP runs in Report-Only mode for now — see ``_build_csp`` for the
-    rationale and the rollout plan to switch to enforcement.
+    CSP is enforcing now (post-#82). The Report-Only phase under #77 ran
+    clean in dev, so violations block the request at the browser instead
+    of merely being reported. The ``report-uri /api/csp-report`` directive
+    inside the CSP string stays, so any future regression still surfaces
+    in logs even though it's blocked at runtime.
     """
     response = await call_next(request)
     response.headers.setdefault("X-Frame-Options", "DENY")
@@ -145,8 +149,8 @@ async def security_headers(request: Request, call_next):
         "Strict-Transport-Security",
         "max-age=31536000; includeSubDomains",
     )
-    if _CSP_REPORT_ONLY is not None:
-        response.headers.setdefault("Content-Security-Policy-Report-Only", _CSP_REPORT_ONLY)
+    if _CSP is not None:
+        response.headers.setdefault("Content-Security-Policy", _CSP)
     return response
 
 

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -126,3 +126,40 @@ def test_build_csp_allows_google_fonts():
     csp = _build_csp("https://keycloak.example.com")
     assert "https://fonts.googleapis.com" in csp
     assert "https://fonts.gstatic.com" in csp
+
+
+# ---------------------------------------------------------------------------
+# CSP — header attached to responses (enforcing, post-#82)
+# ---------------------------------------------------------------------------
+
+
+def test_csp_header_is_enforcing_not_report_only(monkeypatch):
+    """Lock in the post-#82 contract: the header is `Content-Security-Policy`
+    (enforcing), not `Content-Security-Policy-Report-Only`. Regression
+    guard against a downgrade back to Report-Only mode."""
+    import backend.app as app_module
+
+    monkeypatch.setattr(app_module, "_CSP", "default-src 'self'; report-uri /api/csp-report")
+
+    client = TestClient(_build_app())
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert "Content-Security-Policy" in resp.headers
+    assert "Content-Security-Policy-Report-Only" not in resp.headers
+    assert "report-uri /api/csp-report" in resp.headers["Content-Security-Policy"]
+
+
+def test_csp_header_absent_when_keycloak_url_empty(monkeypatch):
+    """Local-dev path with AUTH_ENABLED=false leaves _CSP=None, so no
+    CSP header is attached (the other baseline headers still are)."""
+    import backend.app as app_module
+
+    monkeypatch.setattr(app_module, "_CSP", None)
+
+    client = TestClient(_build_app())
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert "Content-Security-Policy" not in resp.headers
+    assert "Content-Security-Policy-Report-Only" not in resp.headers
+    # Baseline headers still present.
+    assert resp.headers["X-Frame-Options"] == "DENY"


### PR DESCRIPTION
Closes #82.

## Summary

The Report-Only phase introduced in #77 ran clean — no \`CSP violation report\` lines in the dev pod logs since the feature deployed. Promoting the header from \`Content-Security-Policy-Report-Only\` to \`Content-Security-Policy\` so violations block at the browser instead of merely being reported.

## Changes

- \`backend/app.py\`:
  - Rename \`_CSP_REPORT_ONLY\` → \`_CSP\` (the header name was the only Report-Only marker; the variable name made it confusing).
  - Switch the header to \`Content-Security-Policy\`. Keep \`report-uri /api/csp-report\` inside the policy string so future regressions still surface in logs even though they're now blocked at runtime.
  - Updated the docstrings of \`_build_csp\` and the \`security_headers\` middleware.
- \`tests/test_security_headers.py\`:
  - \`test_csp_header_is_enforcing_not_report_only\` — regression guard against a downgrade back to Report-Only.
  - \`test_csp_header_absent_when_keycloak_url_empty\` — keeps the local-dev path (AUTH_ENABLED=false, KEYCLOAK_URL=\"\") working without a CSP header.

## Test plan

- [x] \`pytest -q\` → 248 passed (32 deselected).
- [x] Both new tests green.
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] Post-merge in dev: load the SPA, exercise login + each tab + chart + backtest. DevTools console shows no \"Refused to ... in violation of the following Content Security Policy directive\" messages.
- [ ] Post-merge: \`POST /api/csp-report\` keeps returning 204 if any violation does fire.
- [ ] Same checks in QA when the next \`v0.1.x-rcN\` builds with this change.

## Out of scope (per issue)

- Nonces for \`style-src\` — Recharts and lightweight-charts inject inline styles, so \`'unsafe-inline'\` stays for now.

## Rollback

If a real-world violation breaks the SPA in dev, revert this PR. The header flip is one line; revert is fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)