### PR TITLE
feat(security): per-route rate limits on creation endpoints (#83)

### DIFF
--- a/backend/api/profile_routes.py
+++ b/backend/api/profile_routes.py
@@ -15,11 +15,12 @@ from __future__ import annotations
 import secrets
 from datetime import UTC, datetime, timedelta
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from backend.auth import AuthUser, get_current_user
 from backend.config import TELEGRAM_BOT_USERNAME, TELEGRAM_ENABLED
 from backend.database import get_db
+from backend.rate_limit import limiter
 
 router = APIRouter(tags=["profile"])
 
@@ -54,7 +55,11 @@ async def get_telegram_status(user: AuthUser = Depends(get_current_user)) -> dic
 
 
 @router.post("/profile/telegram/link-token")
-async def create_link_token(user: AuthUser = Depends(get_current_user)) -> dict:
+@limiter.limit("5/minute")
+async def create_link_token(
+    request: Request,
+    user: AuthUser = Depends(get_current_user),
+) -> dict:
     """Generate a one-time token the user can send to the bot as ``/start <token>``."""
     if not TELEGRAM_ENABLED:
         raise HTTPException(

--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -6,11 +6,12 @@ import json
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from backend.auth import AuthUser, get_current_user
 from backend.database import get_db
+from backend.rate_limit import limiter
 
 router = APIRouter(tags=["signals"])
 
@@ -76,7 +77,9 @@ class RealTradePatch(BaseModel):
 
 
 @router.post("/signals/configs")
+@limiter.limit("10/minute")
 async def create_signal_config(
+    request: Request,
     req: SignalConfigCreate,
     user: AuthUser = Depends(get_current_user),
 ) -> dict:
@@ -223,7 +226,9 @@ async def patch_signal_config(
 
 
 @router.post("/signals/configs/{config_id}/reset-equity")
+@limiter.limit("10/minute")
 async def reset_signal_config_equity(
+    request: Request,
     config_id: int,
     user: AuthUser = Depends(get_current_user),
 ) -> dict:
@@ -484,7 +489,9 @@ async def list_sim_trade_stop_moves(
 
 
 @router.post("/sim-trades/{trade_id}/close")
+@limiter.limit("30/minute")
 async def close_sim_trade(
+    request: Request,
     trade_id: int,
     user: AuthUser = Depends(get_current_user),
 ) -> dict:
@@ -572,7 +579,9 @@ async def close_sim_trade(
 
 
 @router.post("/real-trades")
+@limiter.limit("10/minute")
 async def create_real_trade(
+    request: Request,
     req: RealTradeCreate,
     user: AuthUser = Depends(get_current_user),
 ) -> dict:
@@ -655,7 +664,9 @@ async def list_real_trades(
 
 
 @router.patch("/real-trades/{trade_id}")
+@limiter.limit("30/minute")
 async def patch_real_trade(
+    request: Request,
     trade_id: int,
     req: RealTradePatch,
     user: AuthUser = Depends(get_current_user),

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -29,9 +29,20 @@ def _use_temp_db(tmp_path):
     db_path = str(tmp_path / "test_authz.db")
     os.environ["DB_PATH"] = db_path
     import backend.database as dbmod
+    from backend.rate_limit import limiter
 
     dbmod.DB_PATH = Path(db_path)
-    yield
+    # Disable rate limiting for the duration of the test. The per-route caps
+    # added in #83 (e.g. POST /signals/configs at 10/minute) are keyed by
+    # client IP — TestClient defaults to a single host ("testclient") so the
+    # bucket fills across tests. Restore on teardown so other test modules
+    # see the production-default state.
+    prev_enabled = limiter.enabled
+    limiter.enabled = False
+    try:
+        yield
+    finally:
+        limiter.enabled = prev_enabled
 
 
 def _now_iso() -> str:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -7,7 +7,7 @@ SlowAPI middleware on a minimal app, and exercises 200 → 200 → 429.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -103,3 +103,36 @@ def test_client_key_returns_unknown_when_no_source():
 def test_client_key_strips_whitespace_in_xff():
     req = _FakeRequest(headers={"x-forwarded-for": "   203.0.113.3   "})
     assert client_key(req) == "203.0.113.3"
+
+
+# ---------------------------------------------------------------------------
+# Per-route limit stacks over the application-wide cap (post-#83)
+# ---------------------------------------------------------------------------
+
+
+def test_per_route_limit_overrides_global_cap():
+    """A per-route ``@limiter.limit("2/minute")`` decorator caps that route
+    specifically even when the global ``application_limits`` is much higher.
+    Locks in the slowapi semantics that #83 relies on for the creation
+    endpoints (POST /signals/configs at 10/minute, etc.)."""
+    limiter = Limiter(
+        key_func=client_key,
+        application_limits=["60/minute"],
+        enabled=True,
+    )
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+    app.add_middleware(SlowAPIMiddleware)
+
+    @app.post("/create")
+    @limiter.limit("2/minute")
+    async def create(request: Request):
+        return {"ok": True}
+
+    client = TestClient(app)
+    r = client.post("/create")
+    assert r.status_code == 200, r.text
+    assert client.post("/create").status_code == 200
+    resp = client.post("/create")
+    assert resp.status_code == 429


### PR DESCRIPTION
Closes #83.

## Summary

Stacks per-route rate limits on top of the application-wide 60/min cap from #76. Six creation endpoints get their own tighter ceiling so an authenticated client can't drown the DB by spamming writes:

| Endpoint | Limit |
|---|---|
| POST /api/signals/configs | 10/minute |
| POST /api/signals/configs/{id}/reset-equity | 10/minute |
| POST /api/sim-trades/{id}/close | 30/minute |
| POST /api/real-trades | 10/minute |
| PATCH /api/real-trades/{id} | 30/minute |
| POST /api/profile/telegram/link-token | 5/minute |

Each handler gains a \`request: Request\` parameter (slowapi extracts the client key from it) and a \`@limiter.limit(\"X/minute\")\` decorator.

## Test changes

- **\`test_rate_limit.py\`** — new \`test_per_route_limit_overrides_global_cap\` locks in the slowapi semantics we depend on: a per-route \`@limiter.limit(\"2/minute\")\` decorator caps that endpoint at 2/min even when \`application_limits=[\"60/minute\"]\`. \`Request\` import promoted to module level (\`from __future__ import annotations\` requires the type to be resolvable from the module scope for FastAPI's signature inspection).
- **\`test_authz.py\`** — \`_use_temp_db\` autouse fixture now flips \`backend.rate_limit.limiter.enabled\` to False for the duration of each test and restores it on teardown. TestClient hits a single host bucket (\`testclient\`) so without this toggle the suite trips its own 10/min cap on POST /signals/configs around test #11. No shared conftest.py per project convention.

## Test plan

- [x] \`pytest -q\` → 247 passed (32 deselected). Up by 1 over baseline (the new rate-limit test).
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] Post-merge: hit \`POST /api/signals/configs\` 11 times within 60s from the same IP — 11th returns 429 with body \`{\"detail\":\"10 per 1 minute\"}\`. Other endpoints unchanged (60/min global still applies).

## Out of scope (per issue)

- Per-user keying (would require running JWT decode before the limiter — middleware reorder).
- Redis-backed shared storage (in-memory is fine until we scale horizontally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)