### PR TITLE
perf(db): asyncpg connection pool for Postgres path (#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ DATABASE_URL=postgresql://... alembic upgrade head
 | `app.py` | FastAPI factory: registers routers, CORS, static file mount, starts two background asyncio loops at lifespan |
 | `config.py` | Reads all env vars once at import; single source of truth for configuration |
 | `auth.py` | Keycloak JWT validation via JWKS. `AUTH_ENABLED=false` bypasses auth with a hard-coded admin user |
-| `database.py` | Unified `get_db()` async context manager. SQLite via `aiosqlite` (dev), PostgreSQL via `asyncpg` (prod). SQLite schema is created inline by `init_db()`; PostgreSQL runs `alembic upgrade head` automatically at startup |
+| `database.py` | Unified `get_db()` async context manager. SQLite via `aiosqlite` (dev), PostgreSQL via `asyncpg` (prod). SQLite schema is created inline by `init_db()`; PostgreSQL runs `alembic upgrade head` automatically at startup. Postgres traffic goes through a shared asyncpg pool (`init_pg_pool` / `close_pg_pool`, hooked into the FastAPI lifespan); pool size is tunable via `PG_POOL_MIN_SIZE` / `PG_POOL_MAX_SIZE` / `PG_POOL_MAX_INACTIVE_LIFETIME` (see `init_pg_pool` docstring) |
 | `binance_client.py` | Async `httpx` Binance Spot API client with 429/418 rate-limit handling and exponential backoff. Singleton instance |
 | `download_engine.py` | Downloads klines in batches with upsert; tracks job progress in `download_jobs` table; `ensure_candles()` auto-fetches missing history |
 | `metrics_engine.py` | Loads klines as pandas DataFrame, computes technical indicators (SMA, EMA, ATR, Donchian, etc.), saves to `derived_metrics` |
@@ -130,6 +130,9 @@ Outbound alerts flow through a single entry point — `notifications.notify_even
 |---|---|---|
 | `DATABASE_URL` | unset | Full PostgreSQL URL; if unset, SQLite is used |
 | `DB_PATH` | `data/trading_tools.db` | SQLite path (ignored when `DATABASE_URL` is set) |
+| `PG_POOL_MIN_SIZE` | `2` | Minimum idle connections in the asyncpg pool |
+| `PG_POOL_MAX_SIZE` | `20` | Maximum connections in the asyncpg pool (per replica) |
+| `PG_POOL_MAX_INACTIVE_LIFETIME` | `300` | Seconds before an idle connection is recycled |
 | `AUTH_ENABLED` | `false` | Set `true` to enable Keycloak JWT validation |
 | `KEYCLOAK_URL` | `""` | Keycloak base URL |
 | `KEYCLOAK_REALM` | `tradingtool-dev` | Keycloak realm |

--- a/backend/app.py
+++ b/backend/app.py
@@ -35,7 +35,7 @@ from backend.config import (
     TELEGRAM_ENABLED,
     TELEGRAM_WEBHOOK_URL,
 )
-from backend.database import get_db, init_db
+from backend.database import close_pg_pool, get_db, init_db, init_pg_pool
 from backend.live_tracker import run_live_tracker
 from backend.rate_limit import limiter
 from backend.signal_engine import run_signal_scanner
@@ -47,7 +47,11 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Database backend: %s", "PostgreSQL" if IS_POSTGRES else "SQLite (ephemeral)")
+    # init_db() runs alembic migrations (Postgres) on a one-shot connection,
+    # so it must complete before the pool is created — otherwise alembic
+    # would race the pool's first acquire on a partially migrated schema.
     await init_db()
+    await init_pg_pool()
 
     if TELEGRAM_ENABLED and TELEGRAM_WEBHOOK_URL:
         logger.info("Registering Telegram webhook at %s", TELEGRAM_WEBHOOK_URL)
@@ -64,6 +68,7 @@ async def lifespan(app: FastAPI):
         await scanner_task
     with contextlib.suppress(asyncio.CancelledError):
         await tracker_task
+    await close_pg_pool()
 
 
 app = FastAPI(

--- a/backend/database.py
+++ b/backend/database.py
@@ -11,6 +11,7 @@ SQLite init_db() creates the schema on first run; PostgreSQL relies on Alembic m
 from __future__ import annotations
 
 import logging
+import os
 import re
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -141,15 +142,86 @@ class _PgCursor:
         return self._rows[0] if self._rows else None
 
 
-@asynccontextmanager
-async def _get_pg_db() -> AsyncIterator[_PgConnection]:
+# Shared asyncpg pool — initialised by ``init_pg_pool()`` at lifespan startup
+# and torn down by ``close_pg_pool()`` at shutdown. Stays ``None`` for the
+# SQLite path. Sized via PG_POOL_MIN_SIZE / PG_POOL_MAX_SIZE /
+# PG_POOL_MAX_INACTIVE_LIFETIME (see init_pg_pool docstring).
+_pg_pool: Any = None
+
+
+async def init_pg_pool() -> None:
+    """Create the shared asyncpg pool. Called from app lifespan startup.
+
+    No-op when ``IS_POSTGRES`` is False — SQLite has no concept of a pool
+    and ``_get_sqlite_db`` opens a fresh connection per call (which is the
+    desired model under aiosqlite + WAL).
+
+    Sizing knobs (env vars):
+    - ``PG_POOL_MIN_SIZE`` (default 2): keep at least this many idle
+      connections warm to absorb burst arrivals without paying handshake.
+    - ``PG_POOL_MAX_SIZE`` (default 20): hard ceiling. Per-replica, so a
+      cluster with N pods can in the worst case open ``N × max`` server
+      connections — keep this in mind when scaling horizontally.
+    - ``PG_POOL_MAX_INACTIVE_LIFETIME`` (default 300s): close idle
+      connections older than this so we recycle through any DB-side
+      connection limits / TLS rotations.
+    """
+    global _pg_pool
+
+    if not IS_POSTGRES:
+        return
+
+    if _pg_pool is not None:
+        return  # already initialised — second lifespan startup, idempotent.
+
     import asyncpg  # noqa: PLC0415
 
-    conn = await asyncpg.connect(DATABASE_URL)
-    try:
+    min_size = int(os.environ.get("PG_POOL_MIN_SIZE", "2"))
+    max_size = int(os.environ.get("PG_POOL_MAX_SIZE", "20"))
+    max_inactive = float(os.environ.get("PG_POOL_MAX_INACTIVE_LIFETIME", "300"))
+
+    log = logging.getLogger(__name__)
+    log.info("Creating asyncpg pool (min=%s max=%s)", min_size, max_size)
+    _pg_pool = await asyncpg.create_pool(
+        DATABASE_URL,
+        min_size=min_size,
+        max_size=max_size,
+        max_inactive_connection_lifetime=max_inactive,
+    )
+
+
+async def close_pg_pool() -> None:
+    """Close the shared asyncpg pool. Called from app lifespan shutdown."""
+    global _pg_pool
+    if _pg_pool is None:
+        return
+    await _pg_pool.close()
+    _pg_pool = None
+
+
+@asynccontextmanager
+async def _get_pg_db() -> AsyncIterator[_PgConnection]:
+    """Acquire a connection from the shared pool.
+
+    Falls back to a one-shot ``asyncpg.connect`` when the pool isn't
+    initialised. That window only exists during ``init_db()`` (which runs
+    Alembic migrations) and inside test code that imports the module
+    without going through ``init_pg_pool()``. Production traffic always
+    goes through the pool because ``init_pg_pool`` runs in the lifespan
+    *before* the FastAPI server starts accepting requests.
+    """
+    import asyncpg  # noqa: PLC0415
+
+    if _pg_pool is None:
+        conn = await asyncpg.connect(DATABASE_URL)
+        try:
+            yield _PgConnection(conn)
+        finally:
+            await conn.close()
+        return
+
+    async with _pg_pool.acquire() as conn:
         yield _PgConnection(conn)
-    finally:
-        await conn.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pg_insert_wrapper.py
+++ b/tests/test_pg_insert_wrapper.py
@@ -70,3 +70,32 @@ async def test_execute_insert_with_explicit_returning_is_not_rewritten():
     # The wrapper must leave the caller's RETURNING untouched — no second append.
     assert sent_query.count("RETURNING") == 1
     assert sent_query.rstrip().endswith("RETURNING token")
+
+
+# ---------------------------------------------------------------------------
+# Pool lifecycle helpers (post-#84)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_init_pg_pool_is_noop_under_sqlite(monkeypatch):
+    """SQLite has no pool concept; init_pg_pool must be a silent no-op so
+    the SQLite test path (which is the entire CI suite today) doesn't try
+    to connect to a Postgres server that isn't there."""
+    import backend.database as dbmod
+
+    monkeypatch.setattr(dbmod, "IS_POSTGRES", False)
+    monkeypatch.setattr(dbmod, "_pg_pool", None)
+    await dbmod.init_pg_pool()
+    assert dbmod._pg_pool is None
+
+
+@pytest.mark.asyncio
+async def test_close_pg_pool_is_safe_when_uninitialized(monkeypatch):
+    """close_pg_pool must not crash if init_pg_pool was never called or was
+    already torn down. Lifespan shutdown can hit this when startup failed."""
+    import backend.database as dbmod
+
+    monkeypatch.setattr(dbmod, "_pg_pool", None)
+    await dbmod.close_pg_pool()  # must not raise
+    assert dbmod._pg_pool is None


### PR DESCRIPTION
Closes #84.

## Summary

Each request was opening a fresh \`asyncpg.connect\` — TCP + TLS + auth on every call, ~10MB RSS server-side per concurrent client. Replace with a shared pool initialised at lifespan startup and torn down at shutdown.

## Changes

\`backend/database.py\`:
- Module-level \`_pg_pool\` (typed \`Any\` to avoid an asyncpg import at module load — the SQLite path doesn't need it).
- \`init_pg_pool()\` creates the pool. No-op when not Postgres or if already initialised (idempotent across lifespan restarts). Sizing via \`PG_POOL_MIN_SIZE\` (default 2), \`PG_POOL_MAX_SIZE\` (default 20), \`PG_POOL_MAX_INACTIVE_LIFETIME\` (default 300s).
- \`_get_pg_db()\` now \`async with _pg_pool.acquire()\`. Falls back to a one-shot \`asyncpg.connect\` if the pool isn't initialised — covers the alembic bootstrap window inside \`init_db()\` and tests that import \`backend.database\` without driving lifespan.
- \`close_pg_pool()\` for clean shutdown.

\`backend/app.py::lifespan\`:
- Order is \`init_db()\` → \`init_pg_pool()\` → start tasks → yield → cancel tasks → \`close_pg_pool()\`. Alembic must run before the pool exists so the first acquire sees a fully migrated schema.

\`tests/test_pg_insert_wrapper.py\`:
- \`test_init_pg_pool_is_noop_under_sqlite\` — keeps the entire SQLite test suite from accidentally trying to talk to a Postgres server.
- \`test_close_pg_pool_is_safe_when_uninitialized\` — shutdown idempotency in case startup failed midway.

\`CLAUDE.md\`:
- Three new env vars in the table + a one-line pointer in the \`database.py\` row.

## Test plan

- [x] \`pytest -q\` → 250 passed (32 deselected). Up by 2 over baseline (the new lifecycle tests).
- [x] \`ruff check\` + \`ruff format --check\` clean.
- [ ] Post-merge in dev: \`kubectl -n data-dev exec ... -c postgres -- psql -U postgres -c \"SELECT count(*), application_name FROM pg_stat_activity WHERE application_name LIKE 'tradingtool%' GROUP BY application_name;\"\` should show ≤ \`max_size\` (default 20) connections per replica with most idle, instead of N (~req concurrentes).
- [ ] Optional bench: \`hey -n 200 -c 10 -H \"Authorization: Bearer ...\" https://tradingtool-dev.../api/signals/configs\` — p99 should drop because the handshake-per-request cost is gone.

## Out of scope (per issue)

- **Option B / pgbouncer**: cluster-side pool. Worth doing once we scale horizontally to N replicas and the per-pod pool ceilings start summing up uncomfortably against Postgres' \`max_connections\`.
- Read replicas / read-only pool.

## Rollback

Revert this PR. The lifespan order makes the rollback clean — without \`init_pg_pool\`, \`_get_pg_db\` falls back to the original one-shot \`asyncpg.connect\` behaviour automatically (the fallback exists for the alembic-bootstrap path anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)