### PR TITLE
ops(scheduling): pin app pods to worker nodes via nodeSelector (#87)

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -16,6 +16,18 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -39,6 +39,21 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# Schedule app pods only on worker nodes by default. k3s does not taint
+# control-plane nodes, so without this hint the scheduler is happy to
+# place app pods on master1, where they compete with control-plane
+# components for CPU/RAM. All workers in the cluster have the
+# `node-role.kubernetes.io/worker=true` label. Override per-env (e.g.
+# `nodeSelector: {}`) if you ever need to run on master for debugging.
+# See #87.
+nodeSelector:
+  node-role.kubernetes.io/worker: "true"
+
+# Hooks reserved for per-env overrides — kept empty so an override can
+# add the block cleanly without re-declaring nodeSelector context.
+affinity: {}
+tolerations: []
+
 # Pod-level security context applied to every container. Per-container
 # overrides live below in `securityContext` (app) and
 # `cloudflareTunnel.securityContext` (sidecar). See #78.


### PR DESCRIPTION
Closes #87.

## Summary

Verified hoy: el dev pod corre en \`master1\` (\`kubectl -n tradingtool-dev get pod -o wide\`). k3s no aplica taint \`NoSchedule\` al control-plane por defecto, así que el scheduler trata master como un nodo más. Acoplamiento que no queremos: un OOM del pod de la app puede tirar componentes del control-plane.

## Cambios

- \`helm/values.yaml\`: \`nodeSelector: {node-role.kubernetes.io/worker: \"true\"}\` por defecto. Hooks \`affinity: {}\` y \`tolerations: []\` reservados para overrides por entorno.
- \`helm/templates/deployment.yaml\`: tres \`{{- with .Values.X }}\` antes de \`containers:\`. Cada uno renderiza sólo si el value no está vacío, así los defaults \`affinity\` / \`tolerations\` no ensucian el manifest.

\`dev.yaml\` y \`qa.yaml\` no tocados — heredan el default.

## Por qué nodeSelector y no nodeAffinity

Match trivial sobre un único label que ya existe en todos los workers — cubre el caso. \`nodeAffinity\` se justifica cuando hace falta lógica más rica (preferred + weights, varios labels combinados, performance tiers). Si más adelante queremos preferir nodos con \`node.kubernetes.io/performance=high\` para los backtests, se migra entonces.

## Por qué no tainear el master

Es una acción cluster-wide. Otras apps en otros namespaces (Keycloak, CNPG, Argo, cloudflared, etc.) podrían estar usando master1 deliberadamente. El control debe vivir donde está la responsabilidad: el chart de la app dice \"yo voy en workers\". Portable a otros clusters sin asumir taints externos.

## Test plan

- [x] \`helm lint helm/\` clean.
- [x] \`helm template tradingtool helm/ -f helm/env/dev.yaml\` muestra el bloque \`nodeSelector\` renderizado donde debe; \`affinity\` / \`tolerations\` no aparecen porque sus valores son vacíos.
- [x] \`helm template ... --set nodeSelector=\` (override empty) → nodeSelector se omite limpiamente. Confirma la semántica de override.
- [ ] Post-merge en dev (Argo dev sync-manual): \`kubectl -n tradingtool-dev get pod -o wide\` → todos los pods en \`worker[1-6]\`, ninguno en \`master1\`.
- [ ] Post-merge en qa (Argo qa sync-automated en cuanto el siguiente \`vX.Y.Z-rcN\` recoja el cambio): mismo check.

## Edge case que estoy aceptando

Si por algún motivo todos los workers están NotReady (worker2 hoy lo está), el pod queda \`Pending\` con \`0/N nodes available: didn't match Pod's node affinity/selector\`. Es el comportamiento correcto: prefiero \`Pending\` claro a un fallback silencioso a master.

## Out of scope (per issue)

- Tainting master cluster-wide.
- Pod anti-affinity para distribuir réplicas (cuando escalemos a >1).
- Performance tiers (\`node.kubernetes.io/performance=high|low\`).
- \`topologySpreadConstraints\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)