### PR TITLE
fix(ops): roll dev image back + drop helm/env from CI paths-ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,16 @@
 name: CI
 
+# `paths-ignore` deliberately empty: the `develop-merge-protection` ruleset
+# requires Lint backend / Lint frontend / Test backend / Build frontend,
+# and any path filter here risks a catch-22 where a PR touches only
+# ignored paths → CI skips → required checks never report → mergeStateStatus
+# = BLOCKED. The auto-bot tag bumps to helm/env/{dev,qa}.yaml don't go
+# through PRs anyway (they push directly to develop), so PR-time filtering
+# never helped them.
 on:
   pull_request:
     branches:
       - develop
-    paths-ignore:
-      # Auto-bot commits to helm/env/{dev,qa}.yaml only flip the image tag
-      # — no need to re-run lint/tests for those.
-      - "helm/env/**"
 
 jobs:
   lint-backend:

--- a/helm/env/dev.yaml
+++ b/helm/env/dev.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "dev-aa10ba5"
+  tag: "dev-5305c6b"
 namespace:
   name: "tradingtool-dev"
   create: true


### PR DESCRIPTION
## Síntoma

Tras mergear #102, build-dev construyó la imagen \`dev-aa10ba5\`. El bot escribió \`dev-aa10ba5\` en \`helm/env/dev.yaml\`, Argo sincronizó, y el pod nuevo entró en \`ImagePullBackOff\`. El sitio NO está caído — el pod viejo (\`84cf8d64bb-kgj4d\` con \`dev-5305c6b\`) sigue 2/2 Running sirviendo tráfico — pero está degraded.

## Causa raíz

El job \`cleanup-old-versions\` de \`build-dev.yml\` borró el child manifest arm64 de \`dev-aa10ba5\` (\`sha256:2f3d8918641d50e285041e34fd2d3c1c0b07c748b1619bf0a1ebdadb1e419c9f\`). Verificado:

\`\`\`
$ podman manifest inspect ghcr.io/.../tradingtools:dev-aa10ba5
  amd64: sha256:60ab5aad...   ← OK
  arm64: sha256:2f3d8918...   ← MISSING
$ podman pull ghcr.io/.../tradingtools@sha256:2f3d8918...
  Error: manifest unknown
\`\`\`

El cluster k3s es arm64, así que la imagen no se puede pullar.

\`actions/delete-package-versions@v5\` con \`min-versions-to-keep: 15\` y \`delete-only-untagged-versions: false\` no es manifest-list-aware: trata cada child como una package version independiente, los ordena por \`created_at\` DESC y borra los más antiguos. Cuando llevamos varios builds en el día (hoy hicimos ~10), el child arm64 de la última imagen termina entre los borrables. Bug latente desde el principio del repo, hoy explotó por la cantidad de merges.

## Cambios

1. \`helm/env/dev.yaml\`: rollback a \`dev-5305c6b\` (la imagen que el pod viejo está corriendo, confirmado healthy). Tras Argo Sync se descartará el pod broken.
2. \`.github/workflows/ci.yml\`: quito \`helm/env/**\` de \`paths-ignore\`. Era el último resto del catch-22 que cerramos parcialmente en #102. Un PR que solo toca \`helm/env/**\` saltaba CI → required checks no reportaban → BLOCKED. Las tag-bumps del bot van por push directo a develop, nunca por PR, así que filtrar PR-time por helm/env/** no servía para nada.

## Por qué coupling en un PR

Necesito el cambio de ci.yml para que este PR mismo sea mergeable. Si solo modifico dev.yaml, hit el catch-22. Ambos archivos están dentro del \`paths-ignore\` de \`build-dev.yml\` (\`.github/workflows/**\` + \`helm/env/**\`), así que la merge NO dispara build-dev → la rollback no se sobreescribe al instante con otro build que volvería a ser víctima del mismo race.

## Follow-up (PR separado)

- Subir \`cleanup-old-versions: min-versions-to-keep\` para que aguante la actividad de un día con varios builds. Valor candidato: 50 (≈16 multi-arch builds completos).
- Investigar arquitectura más sana: cleanup explícito por tag pattern (\`dev-*\` con N días de antigüedad) en lugar de por created_at; o pasar a \`delete-only-untagged-versions: true\` con cuidado para no borrar children referenciados.
- Documentar el incidente en CLAUDE.md \"CI gotchas\".

## Smoke E2E QA — separado pero observado

El recovery de \`v0.1.0-rc2\` produjo el QA build correctamente y Argo desplegó el pod (\`f94c55c64-j8qrs\`, 2/2 Running con \`v0.1.0-rc2\`). Pero la **Smoke E2E** falló con \`HTTP 403\` desde Cloudflare Access en cada poll de \`/healthz\` durante 10 min — los secrets \`CF_ACCESS_CLIENT_ID\` / \`CF_ACCESS_CLIENT_SECRET\` no validan contra la policy actual del CF Access Application de QA. Es config issue de Cloudflare, no del código. El job es \`continue-on-error: true\` así que no bloqueó la promoción. Otro tema para revisar a tu lado.

## Test plan

- [x] CI corre normal en este PR (ci.yml está fuera de su propio paths-ignore).
- [ ] Post-merge: \`build-dev.yml\` NO se dispara (ambas paths matchean su \`paths-ignore\`).
- [ ] Post-merge + Argo Sync manual en dev: \`kubectl -n tradingtool-dev get pods\` → solo el pod con \`dev-5305c6b\`, status 2/2 Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)