### PR TITLE
fix(ci): add SHA-256 fingerprint diagnostic to smoke E2E secrets

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -219,6 +219,15 @@ jobs:
           ID=$(printf '%s' "$RAW_ID"     | tr -d '[:space:]')
           SECRET=$(printf '%s' "$RAW_SECRET" | tr -d '[:space:]')
           echo "CF Access header lengths: id=${#ID} secret=${#SECRET} (expected id=39 secret=64)"
+          # Fingerprint = first 8 hex chars of SHA-256 of the trimmed value.
+          # Enough to detect byte-level mismatches between this stored value
+          # and a known-good reference (e.g. the user's local shell), but
+          # short enough not to leak the secret. To compare locally:
+          #   echo -n "$CF_ID"     | sha256sum | cut -c1-8
+          #   echo -n "$CF_SECRET" | sha256sum | cut -c1-8
+          ID_FP=$(printf '%s' "$ID"     | sha256sum | cut -c1-8)
+          SECRET_FP=$(printf '%s' "$SECRET" | sha256sum | cut -c1-8)
+          echo "CF Access header fingerprints (sha256[:8]): id=$ID_FP secret=$SECRET_FP"
           if [ -z "$ID" ] || [ -z "$SECRET" ]; then
             echo "::warning::CF_ACCESS_CLIENT_ID or _SECRET is empty after trim — secrets likely unset"
           fi


### PR DESCRIPTION
Diagnóstico continuo del 403 del smoke E2E. Tras #105 sabemos que el length de los secrets es \`id=39 secret=64\` (correcto) y que no hay whitespace al rededor. Pero curl local con los mismos valores da 200 y el smoke sigue 403, así que los bytes NO son los mismos pese a parecerlo.

## Cambio

Una línea más en el step \`Normalise CF Access headers + length sanity\`: imprime los primeros 8 chars hex del SHA-256 de cada valor trimmed.

\`\`\`
CF Access header lengths: id=39 secret=64 (expected id=39 secret=64)
CF Access header fingerprints (sha256[:8]): id=ab12cd34 secret=ef56ab78
\`\`\`

Suficiente entropía para detectar cualquier diferencia byte-a-byte; no suficiente para reconstruir el valor (8 hex = 32 bits, brute-forceable solo si tienes el espacio de búsqueda).

## Comparación local

En tu shell con los valores conocidos buenos (los que dan 200 en tu curl directo):

\`\`\`bash
read -rs -p "Client ID: " CF_ID; echo
read -rs -p "Client Secret: " CF_SECRET; echo
echo -n \"$CF_ID\"     | sha256sum | cut -c1-8
echo -n \"$CF_SECRET\" | sha256sum | cut -c1-8
unset CF_ID CF_SECRET
\`\`\`

Resultados posibles tras el próximo run:
- **Fingerprints coinciden** → los bytes en GitHub son los mismos que en tu shell. El 403 ya no puede ser por valor; toca mirar el lado de CF (UUID huérfano en la policy, token deshabilitado, etc.).
- **Fingerprints difieren** → GitHub tiene bytes distintos de los que tú crees haber pegado. Lo más probable: confusable Unicode al copiar del UI de CF. Solución: copiar desde un sitio que sólo permita ASCII (un editor en modo \"plain text\") y re-set vía \`gh secret set --body\`.

## Test plan

- [x] YAML parsea, line añadida sólo en el step de normalisation, sin tocar curl ni request.
- [ ] Post-merge + \`gh workflow run build-qa.yml --ref develop\` (o re-run del job): el log incluye la línea \`fingerprints (sha256[:8])\` con los dos prefijos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)