### PR TITLE
fix(ci): probe /healthz once and dump response in smoke E2E (diagnostic)

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -240,6 +240,37 @@ jobs:
           echo "::add-mask::$ID"
           echo "::add-mask::$SECRET"
 
+      # Diagnostic single shot before the wait loop. Captures status code,
+      # response headers and the first 500 bytes of body. The wait loop
+      # below only knows "non-2xx" — but the body/headers tell us WHO
+      # is denying:
+      #   - HTML "Just a moment..." / "Attention Required!" → CF Bot Fight
+      #     Mode / Super Bot Fight Mode is challenging the runner before
+      #     Access ever evaluates the policy.
+      #   - HTML / JSON with `cf-mitigated` header set → CF firewall rule.
+      #   - JSON `{"errors": [...]}` from Access → policy mismatch (token
+      #     not in policy, UUID stale, etc.). At this point only this
+      #     case means we still have a value/policy problem.
+      # Header values are masked by the prior `::add-mask::` calls so the
+      # log never echoes them. (Local fallback if the smoke is gone:
+      # `curl -i ... | head -c 1500`.)
+      - name: Probe /healthz once and dump response (diagnostic)
+        run: |
+          set +e
+          response=$(curl -sS -o /tmp/cf_body.txt -w 'http=%{http_code} cf_ray=%header{cf-ray} cf_mitigated=%header{cf-mitigated} server=%header{server}\n' \
+            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
+            -D /tmp/cf_headers.txt \
+            "$QA_BASE_URL/healthz")
+          echo "$response"
+          echo "---response headers---"
+          head -30 /tmp/cf_headers.txt || true
+          echo "---response body (first 500 bytes)---"
+          head -c 500 /tmp/cf_body.txt || true
+          echo
+          echo "---/end of probe---"
+          rm -f /tmp/cf_body.txt /tmp/cf_headers.txt
+
       - name: Wait for /healthz
         run: |
           set -euo pipefail


### PR DESCRIPTION
Continuación del diagnóstico.

Tras #105 (length+trim) y #106 (sha fingerprints) hemos confirmado byte-igualdad entre el secret en GitHub y el valor local. Local curl da 200, smoke en Actions da 403. El input es idéntico, así que la diferencia tiene que estar en cómo CF trata la request — no en el contenido del header de Access.

## Hipótesis vivas

1. **Bot Fight Mode** del zone marca a los runners de GH como bots y bloquea ANTES de Access. Body sería HTML \"Just a moment...\" o \"Attention Required!\".
2. **WAF rule** filtrando por user-agent (\`curl/8.x\`) o ASN. Body HTML, header \`cf-mitigated\` set.
3. **Bypass policy con criterio que excluye los IPs**. Body JSON de Access con texto de denegación.

## Cambio

Step nuevo \`Probe /healthz once and dump response (diagnostic)\` antes del wait loop. Hace UNA curl, escribe headers + status + body (truncado a 500B) al log. El wait loop sigue tal cual.

Los valores de los headers de Access están enmascarados por \`::add-mask::\` desde #105, así que no se filtran al log. Lo que vamos a poder leer:
- \`cf-ray\` → identifica el data-center; si CF quiere podemos buscarlo en Logs.
- \`cf-mitigated\` (si aparece) → cualquier acción del firewall sí lo setea.
- \`server\` → \`cloudflare\` confirma que la respuesta sale de CF, no de origin.
- Primeros 500 bytes de body → la diferencia diagnóstica entre las tres hipótesis.

## Test plan

- [x] YAML parsea, step nuevo va antes del \"Wait for /healthz\".
- [ ] Post-merge + \`gh workflow run build-qa.yml --ref develop\`: log incluye un bloque \`response headers\` y \`response body\` con la respuesta real del 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)