### PR TITLE
fix(ci): capture Keycloak 4xx response body in smoke E2E login

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -313,16 +313,32 @@ jobs:
           # No CF-Access headers here — Keycloak lives on a different host
           # (keycloak-dev.liontechsolution.com) outside the qa Access
           # Application.
-          token=$(curl -fsS -X POST \
+          # Capture status + body to a tempfile so a 4xx/5xx response shows
+          # Keycloak's `{"error": "...", "error_description": "..."}` JSON
+          # in the log instead of a bare exit-22 from curl. Common errors:
+          #   unauthorized_client   → Direct Access Grants disabled on client
+          #   invalid_grant         → user/password wrong or user disabled
+          #   invalid_client        → client confidential, missing client_secret
+          status=$(curl -s -o /tmp/kc_response.json -w '%{http_code}' \
+            -X POST \
             "${KEYCLOAK_URL%/}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" \
             -d "client_id=${KEYCLOAK_CLIENT_ID}" \
             -d "username=${SMOKE_USER}" \
             -d "password=${SMOKE_PASSWORD}" \
             -d "grant_type=password" \
-            -d "scope=openid" \
-            | jq -r '.access_token')
+            -d "scope=openid")
+          if [ "$status" != "200" ]; then
+            echo "Keycloak token endpoint returned HTTP $status" >&2
+            echo "---response body---" >&2
+            head -c 500 /tmp/kc_response.json >&2
+            echo >&2
+            rm -f /tmp/kc_response.json
+            exit 1
+          fi
+          token=$(jq -r '.access_token' < /tmp/kc_response.json)
+          rm -f /tmp/kc_response.json
           if [ -z "$token" ] || [ "$token" = "null" ]; then
-            echo "Token retrieval failed" >&2
+            echo "Token retrieval failed (200 but no access_token in response)" >&2
             exit 1
           fi
           echo "::add-mask::$token"


### PR DESCRIPTION
Diagnóstico análogo al de #107 pero para el step \`Login as service user (Direct Access Grants)\` del smoke. Hoy nos quedamos en \`exit 22\` de curl tras un 400 de Keycloak sin saber por qué.

## Cambio

El curl ya no usa \`-fsS\`. Capturo status code via \`-w\` y body a tempfile via \`-o\`. Si \`!= 200\`, vuelco los primeros 500 bytes del body al stderr — donde Keycloak siempre escribe el JSON de error con \`error\` + \`error_description\`. Si 200, leo el access_token del mismo tempfile y sigo igual que antes.

## Causas típicas que el body delatará

| error | error_description | causa |
|---|---|---|
| \`unauthorized_client\` | Client not allowed for direct access grants | Client \`tradingtool-api\` sin \"Direct Access Grants Enabled\" en realm tradingtool-qa |
| \`invalid_grant\` | Invalid user credentials | User/password mal o user disabled |
| \`invalid_client\` | Invalid client or Invalid client credentials | Client confidential que pide client_secret |
| \`invalid_request\` | Account is disabled / not fully set up | User existe pero requiere reset, MFA, etc. |

## Test plan

- [x] Sintaxis YAML OK.
- [ ] Post-merge + \`gh workflow run build-qa.yml --ref develop\`: si Keycloak devuelve 4xx, el log muestra \`Keycloak token endpoint returned HTTP 400\` seguido de \`---response body---\` con el JSON exacto.
- [ ] Si todo está bien: el step pasa silently a 200 igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)