### PR TITLE
fix(ci): smoke round-trip jq filter (rc7 final smoke step)

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -360,12 +360,16 @@ jobs:
             -d "$payload")
           id=$(jq -r '.id' <<<"$created")
           echo "Created config id=$id"
+          # GET /api/signals/configs returns {"configs": [...]}, not a bare
+          # array. The previous filter `.[] | select(.id == $id)` iterated
+          # the wrapping object's keys and tried `.id` on the inner array,
+          # which fails with "Cannot index array with string 'id'".
           curl -fsS \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
             -H "Authorization: Bearer $TOKEN" \
             "$QA_BASE_URL/api/signals/configs" \
-            | jq -e ".[] | select(.id == $id)" > /dev/null
+            | jq -e ".configs[] | select(.id == $id)" > /dev/null
           curl -fsS -X DELETE \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \


### PR DESCRIPTION
Último blocker del smoke E2E.

## Síntoma

Tras arreglar Bot Fight Mode (zone OFF), Direct Access Grants en el client de Keycloak (#realm fix) y el user fully-set-up (email/firstName/lastName añadidos), el smoke avanzó al último step y cayó:

\`\`\`
Created config id=1
jq: error (at <stdin>:0): Cannot index array with string \"id\"
##[error]Process completed with exit code 5.
\`\`\`

## Causa

El endpoint \`GET /api/signals/configs\` devuelve \`{\"configs\": [...]}\` (wrapping object), no un array bare. El filtro \`.[] | select(.id == $id)\` itera las CLAVES del objeto, encuentra una sola (\`configs\`) cuyo valor es un array, intenta \`.id\` sobre el array y peta. Como tras el POST la config ya está en DB (id=1), todo lo demás funciona — solo el verify-via-GET tiene el filtro mal escrito.

## Fix

Una palabra: \`.[]\` → \`.configs[]\`. Sin tocar payload ni headers.

## Test plan

- [x] YAML parsea.
- [ ] Post-merge + \`gh workflow run tag-qa-release.yml --ref develop -f bump=hotfix\` (o re-trigger del último): smoke pasa entero (Login + POST + GET-verify + DELETE) → \"Round-trip OK.\"
- [ ] El service-token de CF muestra \"Last Seen\" reciente confirmando autenticación end-to-end.

## Out of scope (notado pero no toco)

El payload del POST tiene \`strategy_params\` (Pydantic lo ignora) y \`capital_mode\` (no es un field de \`SignalConfigCreate\`). Pydantic-default-config los descarta sin error → el smoke crea una config con \`params={}\` (vacíos). No bloquea, pero el smoke estaría más estricto si usara los nombres correctos. Lo dejo como follow-up si se quiere afinar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)