### PR TITLE
fix(ci): smoke payload unique per run + correct field name

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -349,9 +349,21 @@ jobs:
         if: steps.login.outputs.skipped == 'false'
         env:
           TOKEN: ${{ steps.login.outputs.token }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
-          payload='{"symbol":"BTCUSDT","interval":"1d","strategy":"breakout","strategy_params":{"lookback":20,"stop_pct":2.0},"initial_portfolio":1000,"leverage":1,"capital_mode":"leverage","cost_bps":10,"telegram_enabled":false,"active":false}'
+          # Each smoke run uses a unique `params.smoke_run_id` so the
+          # (user_id, symbol, interval, strategy, params) unique index
+          # never collides with an orphan from a previous failed run
+          # (the index was added in #74; rc7 left an orphan when the jq
+          # filter bug killed the DELETE step before cleanup, then rc8
+          # 500'd here on the duplicate). Field name is `params` (not
+          # `strategy_params`) so the value is actually persisted by the
+          # SignalConfigCreate Pydantic model — the previous payload
+          # silently dropped the strategy params and stored `params={}`.
+          payload=$(jq -nc \
+            --arg run_id "$RUN_ID" \
+            '{symbol:"BTCUSDT",interval:"1d",strategy:"breakout",params:{lookback:20,stop_pct:2.0,smoke_run_id:$run_id},initial_portfolio:1000,leverage:1,cost_bps:10,telegram_enabled:false}')
           created=$(curl -fsS -X POST "$QA_BASE_URL/api/signals/configs" \
             -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
             -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
@@ -359,7 +371,7 @@ jobs:
             -H "Content-Type: application/json" \
             -d "$payload")
           id=$(jq -r '.id' <<<"$created")
-          echo "Created config id=$id"
+          echo "Created config id=$id (smoke_run_id=$RUN_ID)"
           # GET /api/signals/configs returns {"configs": [...]}, not a bare
           # array. The previous filter `.[] | select(.id == $id)` iterated
           # the wrapping object's keys and tried `.id` on the inner array,


### PR DESCRIPTION
Tras #110, el smoke avanzó hasta el round-trip y rc8 cayó en POST con 500. Causa: rc7 dejó un config huérfano en DB (id=1, params={}) porque la PR anterior #110 arregló el jq filter pero el DELETE tampoco corrió en rc7 (el filter peta antes). rc8 intenta crear el mismo payload otra vez → unique constraint violation → 500 (debería ser 409 pero el error handler tiene un bug de case-sensitivity contra asyncpg, lo trato como follow-up).

## Fixes en este PR

1. **\`params.smoke_run_id\` = \`github.run_id\`** en el payload. Cada run tiene un composite-key único, así los orphans de runs previos no bloquean.
2. **\`params\` en lugar de \`strategy_params\`**. El modelo Pydantic \`SignalConfigCreate\` define el field como \`params: dict\`. Lo que estaba era silenciosamente descartado → cada config del smoke tenía \`params={}\` con independencia de lo que el smoke creyera estar pasando.
3. Removidos \`capital_mode\` y \`active\` del payload — no son fields del modelo, también se descartaban.

Payload construido con \`jq -nc\` para que la sustitución de \`run_id\` sea segura.

## Follow-up (PR/issue separados)

- **Backend bug**: \`backend/api/signal_routes.py::create_signal_config\` hace \`if \"UNIQUE\" in str(exc)\` para detectar duplicados y devolver 409. Funciona en SQLite (\`UNIQUE constraint failed\`) pero no en Postgres asyncpg (\`duplicate key value violates unique constraint\` — minúscula). Resultado: 500 en QA/prod ante duplicados normales. Test que cubra esto + fix con \`re.search(r\"unique\", str(exc), re.IGNORECASE)\` o mejor con un \`except asyncpg.exceptions.UniqueViolationError\` explícito.
- **Limpieza de orphans en QA DB** (los ids creados por rc7 etc.). No bloquea con este fix porque el run_id hace los configs nuevos únicos. Los orphans son \`params={}\`, fácil de eliminar con un \`DELETE FROM signal_configs WHERE json_extract(params, '$.smoke_run_id') IS NULL\` o equivalente Postgres.

## Test plan

- [x] YAML parsea, el step sigue en la misma posición.
- [x] \`jq -nc\` genera el JSON esperado con el campo \`smoke_run_id\` dentro de \`params\` (verificado local).
- [ ] Post-merge + bump rc9: round-trip va verde end-to-end (Created → GET-verify → DELETE → \"Round-trip OK.\").

🤖 Generated with [Claude Code](https://claude.com/claude-code)