### PR TITLE
chore(ci): remove Probe /healthz diagnostic now that smoke is green

### DIFF
--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -240,37 +240,6 @@ jobs:
           echo "::add-mask::$ID"
           echo "::add-mask::$SECRET"
 
-      # Diagnostic single shot before the wait loop. Captures status code,
-      # response headers and the first 500 bytes of body. The wait loop
-      # below only knows "non-2xx" — but the body/headers tell us WHO
-      # is denying:
-      #   - HTML "Just a moment..." / "Attention Required!" → CF Bot Fight
-      #     Mode / Super Bot Fight Mode is challenging the runner before
-      #     Access ever evaluates the policy.
-      #   - HTML / JSON with `cf-mitigated` header set → CF firewall rule.
-      #   - JSON `{"errors": [...]}` from Access → policy mismatch (token
-      #     not in policy, UUID stale, etc.). At this point only this
-      #     case means we still have a value/policy problem.
-      # Header values are masked by the prior `::add-mask::` calls so the
-      # log never echoes them. (Local fallback if the smoke is gone:
-      # `curl -i ... | head -c 1500`.)
-      - name: Probe /healthz once and dump response (diagnostic)
-        run: |
-          set +e
-          response=$(curl -sS -o /tmp/cf_body.txt -w 'http=%{http_code} cf_ray=%header{cf-ray} cf_mitigated=%header{cf-mitigated} server=%header{server}\n' \
-            -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
-            -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-            -D /tmp/cf_headers.txt \
-            "$QA_BASE_URL/healthz")
-          echo "$response"
-          echo "---response headers---"
-          head -30 /tmp/cf_headers.txt || true
-          echo "---response body (first 500 bytes)---"
-          head -c 500 /tmp/cf_body.txt || true
-          echo
-          echo "---/end of probe---"
-          rm -f /tmp/cf_body.txt /tmp/cf_headers.txt
-
       - name: Wait for /healthz
         run: |
           set -euo pipefail


### PR DESCRIPTION
Limpieza post-mortem del incidente del smoke. El step \`Probe /healthz once and dump response (diagnostic)\` se introdujo en #107 para capturar la respuesta real de CF cuando el wait estaba dando 403 — fue útil para confirmar que era Bot Fight Mode (HTML \"Just a moment...\") y no un problema de secrets.

Ahora el smoke va verde (rc9 confirmado: \"Round-trip OK\" con id=3). El Probe ya solo añade ~1s por run y ruido en logs sin aportar diagnóstico mientras todo esté sano. Si vuelve a romperse algo similar, este commit se revierte fácil.

## Lo que se queda del hardening defensivo (cheap, ongoing value)

- **Normalise CF Access headers + length sanity** (#105): trim de whitespace + log de longitud (id=39, secret=64). Pilla newline pasting al instante.
- **SHA-256 fingerprint de los CF Access headers** (#106): permite comparar bytes con un local trusted shell sin filtrar valores.
- **Body capture en Login Keycloak** (#109): Keycloak siempre devuelve JSON útil en 4xx, no hay razón para descartarlo.

## Lo que se quita

- **Probe /healthz once and dump response (diagnostic)** (#107): solo aplica al diagnóstico de Bot Fight Mode, ya conocido y mitigado.

## Test plan

- [x] YAML parsea, los 5 steps restantes en orden.
- [ ] Próximo build-qa run: log de smoke ya no incluye el bloque \"---response headers---\" / \"---response body---\" / \"---/end of probe---\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)