### PR TITLE
ci: smoke validates rolled-out image + skip docs-only dev builds (#108, #114)

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -7,6 +7,9 @@ on:
     paths-ignore:
       - ".github/workflows/**"
       - "helm/env/**"
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-qa.yml
+++ b/.github/workflows/build-qa.yml
@@ -240,23 +240,47 @@ jobs:
           echo "::add-mask::$ID"
           echo "::add-mask::$SECRET"
 
-      - name: Wait for /healthz
+      # Post-#114: poll /healthz until the served `image_tag` matches the
+      # one we just promoted, NOT just any 200. Argo CD QA is sync-automated
+      # but not instant — its default reconcile loop is ~3 min, plus a
+      # 30-60s rollout. Without this check, the smoke fired immediately
+      # after `update-tag` and validated whichever pod was already
+      # serving traffic (i.e. the previous build), turning the whole
+      # smoke into a silent false positive.
+      #
+      # Cap is 4 min: covers the 95th percentile of Argo's reconcile + pull
+      # + readiness window. If we hit timeout consistently, the right
+      # answer is to bump the cap (or set up an Argo→GitHub
+      # repository_dispatch webhook) rather than make the gate softer.
+      - name: Wait for rollout (poll /healthz until image_tag matches)
+        env:
+          EXPECTED_TAG: ${{ needs.resolve-tag.outputs.image_tag }}
         run: |
           set -euo pipefail
-          deadline=$(( $(date +%s) + 600 ))
-          until curl -fsS --max-time 10 \
+          deadline=$(( $(date +%s) + 240 ))
+          attempt=0
+          served_tag="(no-response-yet)"
+          while :; do
+            attempt=$((attempt + 1))
+            body=$(curl -fsS --max-time 10 \
               -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
               -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-              "$QA_BASE_URL/healthz" > /dev/null; do
+              "$QA_BASE_URL/healthz" || true)
+            if [ -n "$body" ]; then
+              served_tag=$(printf '%s' "$body" | jq -r '.image_tag // "unknown"' 2>/dev/null || echo "parse-error")
+            fi
+            if [ "$served_tag" = "$EXPECTED_TAG" ]; then
+              echo "Rollout complete after ${attempt} attempts: served_tag=${served_tag}"
+              break
+            fi
             now=$(date +%s)
             if [ "$now" -ge "$deadline" ]; then
-              echo "Timeout: $QA_BASE_URL/healthz never returned 200 within 10 min" >&2
+              echo "::error::Timeout (4 min): served_tag=${served_tag} expected=${EXPECTED_TAG}. Argo CD likely still rolling out, or rollout failed. Check the trading-tool-qa Application in Argo." >&2
               exit 1
             fi
-            echo "Waiting for QA app to come up..."
-            sleep 15
+            echo "attempt=${attempt} served_tag=${served_tag} expected=${EXPECTED_TAG} — waiting 10s"
+            sleep 10
           done
-          echo "App is healthy."
 
       - name: Verify /api/auth/config returns 200
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Outbound alerts flow through a single entry point — `notifications.notify_even
 | `TELEGRAM_BOT_USERNAME` | `""` | Bot username (no `@`); used to build the `https://t.me/<bot>?start=<token>` deep-link in link-token responses |
 | `TELEGRAM_WEBHOOK_SECRET` | `""` | Secret embedded in the webhook path and verified in the `X-Telegram-Bot-Api-Secret-Token` header |
 | `TELEGRAM_WEBHOOK_URL` | `""` | If set (together with the bot token), `setWebhook` is invoked once at app lifespan startup |
+| `IMAGE_TAG` | `unknown` | Injected by Helm from `.Values.image.tag`; surfaced in `/healthz` so the QA smoke can verify the served pod matches the just-promoted build (#114). Don't read in app code. |
 
 Frontend-only (placed in `frontend/.env.development.local`, only needed to override dev defaults):
 `VITE_AUTH_ENABLED`, `VITE_KEYCLOAK_URL`, `VITE_KEYCLOAK_REALM`, `VITE_KEYCLOAK_CLIENT_ID`
@@ -239,5 +240,5 @@ Replays a fixed klines fixture through both the backtest engine and the live eng
 
 ## QA validation
 
-- **CI smoke E2E** (`build-qa.yml::smoke-e2e`): scripted, runs after every QA build, validates `/healthz` + `/api/auth/config` + Keycloak login + create/get/delete a signal_config. Catches functional regressions on the API surface. **Caveat**: today the smoke fires immediately after `update-tag`, before Argo finishes rolling — it likely hits the OLD pod, not the just-deployed image. Tracked in #114; the fix needs a wait-for-rollout step.
+- **CI smoke E2E** (`build-qa.yml::smoke-e2e`): scripted, runs after every QA build, validates `/healthz` + `/api/auth/config` + Keycloak login + create/get/delete a signal_config. Catches functional regressions on the API surface. Post-#114 the smoke poléa `/healthz` until the served `image_tag` matches the just-promoted rc (cap 4 min, hard-fail on timeout) — so we're always validating the new pod, not whichever pod was already serving traffic during the rolling update. Still soft-gated (`continue-on-error: true`) until the new contract has been green for ~2 weeks of releases.
 - **Deep walkthrough** (`.claude/skills/qa-walkthrough/SKILL.md`): on-demand agent-driven exploration via playwright-cli + Firefox. Triggered only when the user explicitly asks ("haz un walkthrough de qa", "/qa-walkthrough"). Covers visual + functional flows that scripted tests can't judge (broken layouts, blank charts, console errors), creates a dummy config + cleans it up, writes a dated markdown report to `qa-walkthrough-reports/`. Screenshots are gitignored (heavy, regenerable); the markdown reports ARE committed for historical regression review. The skill is project-scoped so it evolves with the codebase — when a new panel ships, add a Stage section to the SKILL.md.

--- a/backend/app.py
+++ b/backend/app.py
@@ -27,6 +27,7 @@ from backend.auth import get_current_user
 from backend.config import (
     AUTH_ENABLED,
     CORS_ORIGINS,
+    IMAGE_TAG,
     IS_POSTGRES,
     KEYCLOAK_AUDIENCE,
     KEYCLOAK_FRONTEND_CLIENT_ID,
@@ -207,7 +208,7 @@ async def auth_config() -> JSONResponse:
 
 @app.get("/healthz", tags=["health"])
 async def liveness() -> JSONResponse:
-    return JSONResponse(content={"status": "alive"})
+    return JSONResponse(content={"status": "alive", "image_tag": IMAGE_TAG})
 
 
 @app.get("/readyz", tags=["health"])

--- a/backend/config.py
+++ b/backend/config.py
@@ -35,6 +35,8 @@ PORT: int = int(os.environ.get("PORT", "8000"))
 HOST: str = os.environ.get("HOST", "0.0.0.0")
 LOG_LEVEL: str = os.environ.get("LOG_LEVEL", "info")
 
+IMAGE_TAG: str = os.environ.get("IMAGE_TAG", "unknown")
+
 
 def _resolve_cors_origins(raw: str, auth_enabled: bool) -> list[str]:
     """Parse CORS_ORIGINS and refuse the wildcard when auth is real.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          env:
+            - name: IMAGE_TAG
+              value: {{ .Values.image.tag | quote }}
           envFrom:
             - configMapRef:
                 name: {{ include "tradingtools.configmapName" . }}

--- a/tests/test_healthz.py
+++ b/tests/test_healthz.py
@@ -1,0 +1,42 @@
+"""Tests for the /healthz endpoint.
+
+Locks in the post-#114 contract: the response body carries an `image_tag`
+field that reflects the IMAGE_TAG env var (Helm injects this from
+.Values.image.tag). The QA smoke E2E polls this field to verify the
+served pod is the one we just promoted, instead of validating an old
+pod still serving traffic during the rolling update.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _build_app() -> FastAPI:
+    """Mount only the /healthz route on a tiny app, bypassing the lifespan
+    in backend.app (which runs init_db and starts background loops)."""
+    from backend.app import liveness
+
+    app = FastAPI()
+    app.add_api_route("/healthz", liveness, methods=["GET"])
+    return app
+
+
+def test_healthz_returns_status_and_image_tag(monkeypatch):
+    monkeypatch.setattr("backend.app.IMAGE_TAG", "test-tag-abc123")
+    client = TestClient(_build_app())
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"status": "alive", "image_tag": "test-tag-abc123"}
+
+
+def test_healthz_image_tag_defaults_when_env_unset(monkeypatch):
+    """When IMAGE_TAG is not injected, the default 'unknown' surfaces.
+    This is the local-dev path; in QA/dev the Helm chart always sets it."""
+    monkeypatch.setattr("backend.app.IMAGE_TAG", "unknown")
+    client = TestClient(_build_app())
+    resp = client.get("/healthz")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "alive", "image_tag": "unknown"}


### PR DESCRIPTION
## Summary

Two CI fixes bundled together; the diff is small enough that one PR keeps the review burden minimal.

- **#108** — `build-dev.yml::paths-ignore` now also excludes `**/*.md`, `docs/**`, and `LICENSE`. Docs-only commits no longer fire an ~80s multi-arch build that produces a bit-identical image and burns 3 GHCR slots toward the 90-version retention.
- **#114** — `build-qa.yml::smoke-e2e` used to fire immediately after `update-tag` and validate whichever pod was already serving traffic during the rolling update — silent false positives. Now it polls `/healthz` until the served `image_tag` matches the rc we just promoted, with a hard 4-min cap and a clear timeout error.
  - `helm/templates/deployment.yaml` injects `IMAGE_TAG` into the app container from `.Values.image.tag`.
  - `backend/config.py` reads it (default `unknown`).
  - `backend/app.py::liveness` echoes it in the `/healthz` JSON body.
  - New `tests/test_healthz.py` locks the contract.
  - `CLAUDE.md` env-var table + QA validation note updated.

## Why combined

Both touch CI, both are low-risk, and the smoke change relies on the fact that docs-only commits aren't going to keep racing it. Two separate commits in the PR (`perf(ci): ...` and `ci(smoke): ...`) so a revert is surgical if needed.

## Why this approach for #114 (vs. Argo Notifications)

Push-with-version-check beats Argo Notifications → repository_dispatch on cost/benefit at our QA cadence (5-10 builds/month). Argo CD QA reconciles ~3 min + ~30-60s rollout, so the cap covers the 95th percentile without burning real minutes on a public-repo runner. If QA cadence ever spikes, switch to a pull model.

## Test plan

- [x] `ruff check backend/ tests/`
- [x] `ruff format --check backend/ tests/`
- [x] `pytest -q` (255 passed, 32 deselected)
- [x] `helm template ... --set image.tag=v0.1.0-rc99` → renders `IMAGE_TAG=v0.1.0-rc99` env var on the app container
- [ ] Post-merge: next QA rc (`gh workflow run "Tag QA release candidate" -f bump=hotfix`) exercises the new poll. Expected log: a few `attempt=N served_tag=qa-<old> expected=v... — waiting 10s` lines, then `Rollout complete after N attempts: served_tag=v...`.
- [ ] Cross-check during that run: `kubectl -n tradingtool-qa get pods -o jsonpath='{.items[0].spec.containers[0].image}'` shows the rc tag.

## Follow-up

Issue (separate, opened alongside this PR) tracks removing `continue-on-error: true` from `smoke-e2e` after ~2 weeks of green runs against the new contract — earliest review date 2026-05-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)