### PR TITLE
feat(frontend): inline help tooltips on form fields (#61)

### DIFF
--- a/frontend/src/components/BacktestPanel.jsx
+++ b/frontend/src/components/BacktestPanel.jsx
@@ -3,6 +3,7 @@ import { apiFetch } from '../auth/apiFetch'
 import EquityChart from './EquityChart'
 import TradeLog from './TradeLog'
 import TradeReviewChart from './TradeReviewChart'
+import FieldLabel from './FieldLabel'
 
 const PAIRS = [
   'BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT',
@@ -74,23 +75,8 @@ const PARAM_META = {
 function ParamLabel({ name, description }) {
   const meta = PARAM_META[name]
   const label = meta?.label ?? name
-  const tip   = meta?.tooltip ?? description ?? ''
-  return (
-    <label className="form-label" style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-      {label}
-      {tip && (
-        <span style={{ position: 'relative', display: 'inline-flex' }} className="param-help-wrap">
-          <span style={{
-            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
-            width: 14, height: 14, borderRadius: '50%',
-            background: 'var(--border-default)', color: 'var(--text-muted)',
-            fontSize: '0.65rem', fontWeight: 700, cursor: 'default', userSelect: 'none', flexShrink: 0,
-          }}>?</span>
-          <span className="param-tooltip">{tip}</span>
-        </span>
-      )}
-    </label>
-  )
+  const tip = meta?.tooltip ?? description ?? ''
+  return <FieldLabel tooltip={tip || undefined}>{label}</FieldLabel>
 }
 
 /* ---- Dynamic parameter form for a strategy ---- */

--- a/frontend/src/components/DataManager.jsx
+++ b/frontend/src/components/DataManager.jsx
@@ -1,5 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { apiFetch } from '../auth/apiFetch'
+import FieldLabel from './FieldLabel'
+
+const FIELD_TIPS = {
+  pair: 'Par de criptomonedas a descargar desde Binance Spot. Solo USDT por ahora.',
+  interval: 'Timeframe de las velas. 1h/4h son los más usados; intervalos más cortos generan más datos y descargas más largas.',
+  startDate: 'Fecha de inicio de la descarga (UTC). Binance tiene historia desde 2017 para BTC; otros pares más recientes.',
+  endDate: 'Fecha final inclusiva. Por defecto es hoy.',
+}
 
 const PAIRS = [
   'BTCUSDT', 'ETHUSDT', 'BNBUSDT', 'SOLUSDT', 'XRPUSDT',
@@ -409,9 +417,8 @@ export default function DataManager() {
         <div className="card-body" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
 
           <div className="grid-2">
-            {/* Pair selector */}
             <div className="form-group">
-              <label className="form-label">Trading Pair</label>
+              <FieldLabel tooltip={FIELD_TIPS.pair}>Trading Pair</FieldLabel>
               <select
                 className="form-control"
                 value={symbol}
@@ -424,9 +431,8 @@ export default function DataManager() {
               </select>
             </div>
 
-            {/* Interval selector */}
             <div className="form-group">
-              <label className="form-label">Interval</label>
+              <FieldLabel tooltip={FIELD_TIPS.interval}>Interval</FieldLabel>
               <select
                 className="form-control"
                 value={interval}
@@ -441,9 +447,8 @@ export default function DataManager() {
           </div>
 
           <div className="grid-2">
-            {/* Start date */}
             <div className="form-group">
-              <label className="form-label">Start Date</label>
+              <FieldLabel tooltip={FIELD_TIPS.startDate}>Start Date</FieldLabel>
               <input
                 type="date"
                 className="form-control"
@@ -454,9 +459,8 @@ export default function DataManager() {
               />
             </div>
 
-            {/* End date */}
             <div className="form-group">
-              <label className="form-label">End Date</label>
+              <FieldLabel tooltip={FIELD_TIPS.endDate}>End Date</FieldLabel>
               <input
                 type="date"
                 className="form-control"

--- a/frontend/src/components/FieldLabel.jsx
+++ b/frontend/src/components/FieldLabel.jsx
@@ -1,0 +1,27 @@
+export default function FieldLabel({ children, tooltip, required, htmlFor, style }) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className="form-label"
+      style={{ display: 'flex', alignItems: 'center', gap: 4, ...style }}
+    >
+      {children}
+      {required && <span aria-hidden="true" style={{ color: 'var(--color-danger)' }}>*</span>}
+      {tooltip && (
+        <span style={{ position: 'relative', display: 'inline-flex' }} className="param-help-wrap">
+          <span
+            aria-label="Field help"
+            role="img"
+            style={{
+              display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+              width: 14, height: 14, borderRadius: '50%',
+              background: 'var(--border-default)', color: 'var(--text-muted)',
+              fontSize: '0.65rem', fontWeight: 700, cursor: 'default', userSelect: 'none', flexShrink: 0,
+            }}
+          >?</span>
+          <span className="param-tooltip">{tooltip}</span>
+        </span>
+      )}
+    </label>
+  )
+}

--- a/frontend/src/components/signals/CapitalConfig.jsx
+++ b/frontend/src/components/signals/CapitalConfig.jsx
@@ -1,3 +1,11 @@
+import FieldLabel from '../FieldLabel'
+
+const TIPS = {
+  portfolio: 'Capital inicial de la cuenta (USD). Inmutable salvo edición manual; arranca = current_portfolio y evoluciona con el PnL neto de cada sim-trade cerrado.',
+  leverage: 'Apalancamiento isolated. 1 = sin leverage. >1 activa el cálculo de precio de liquidación (long: entry × (1 − 1/lev + mm); short: entry × (1 + 1/lev − mm)).',
+  invested: 'Capital efectivo a desplegar por trade en USD. Se traduce internamente a leverage = invested/portfolio.',
+}
+
 export function CapitalConfig({ portfolio, setPortfolio, leverage, setLeverage, investedAmount, setInvestedAmount, mode, setMode, disabled }) {
   return (
     <div>
@@ -17,19 +25,19 @@ export function CapitalConfig({ portfolio, setPortfolio, leverage, setLeverage, 
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-3)' }}>
         <div className="form-group">
-          <label className="form-label">Portfolio (USD)</label>
+          <FieldLabel tooltip={TIPS.portfolio}>Portfolio (USD)</FieldLabel>
           <input type="number" className="form-control" value={portfolio} min={1} step={100}
             onChange={e => setPortfolio(parseFloat(e.target.value) || 0)} disabled={disabled} />
         </div>
         {mode === 'leverage' ? (
           <div className="form-group">
-            <label className="form-label">Leverage</label>
+            <FieldLabel tooltip={TIPS.leverage}>Leverage</FieldLabel>
             <input type="number" className="form-control" value={leverage} min={0.1} step={0.1}
               onChange={e => setLeverage(parseFloat(e.target.value) || 1)} disabled={disabled} />
           </div>
         ) : (
           <div className="form-group">
-            <label className="form-label">Invested Amount (USD)</label>
+            <FieldLabel tooltip={TIPS.invested}>Invested Amount (USD)</FieldLabel>
             <input type="number" className="form-control" value={investedAmount} min={1} step={100}
               onChange={e => setInvestedAmount(parseFloat(e.target.value) || 0)} disabled={disabled} />
           </div>

--- a/frontend/src/components/signals/ConfigForm.jsx
+++ b/frontend/src/components/signals/ConfigForm.jsx
@@ -1,7 +1,27 @@
 import { useState, useEffect } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
+import FieldLabel from '../FieldLabel'
 import { PAIRS, INTERVALS } from './helpers'
 import { CapitalConfig } from './CapitalConfig'
+
+const STRATEGY_PARAM_TIPS = {
+  reversal_pct: 'Mínimo % de retroceso desde el extremo móvil para confirmar un swing (soporte/resistencia). E.g. 0.03 = 3%.',
+  N_entrada: 'Nº de velas hacia atrás para detectar el breakout de entrada (sin contar la actual).',
+  M_salida: 'Nº de velas hacia atrás para la señal de salida. Debe ser ≤ N.',
+  stop_pct: 'Distancia del stop como fracción del precio de referencia de entrada (e.g. 0.02 = 2%).',
+  modo_ejecucion: 'open_next: la orden se llena al open de la siguiente vela (realista). close_current: se llena al close de la vela de señal (optimista).',
+  habilitar_long: 'Permite entradas long (compra) cuando el precio cierra por encima del breakout de la N-vela.',
+  habilitar_short: 'Permite entradas short (venta) cuando el precio cierra por debajo del breakout de la N-vela.',
+  coste_total_bps: 'Coste total round-trip en basis points (1 bps = 0.01%). Cubre fees + slippage de entrada y salida.',
+}
+
+const FIELD_TIPS = {
+  pair: 'Par de criptomonedas a operar. Solo USDT por ahora.',
+  interval: 'Timeframe de las velas. Define cada cuánto evalúa el motor de señales el cierre de vela.',
+  strategy: 'Estrategia a ejecutar. Cada una expone sus propios parámetros más abajo.',
+  costBps: 'Coste de transacción aplicado a cada lado del trade en basis points (1 bps = 0.01%). Binance ≈ 10 bps/lado.',
+  maintenanceMargin: 'Margen de mantenimiento usado para calcular el precio de liquidación. Binance baseline ≈ 0.005 (0.5%) para notional bajo.',
+}
 
 export function ConfigForm({ strategies, onCreated }) {
   const [symbol, setSymbol] = useState('BTCUSDT')
@@ -76,19 +96,19 @@ export function ConfigForm({ strategies, onCreated }) {
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-3)' }}>
         <div className="form-group">
-          <label className="form-label">Pair</label>
+          <FieldLabel tooltip={FIELD_TIPS.pair}>Pair</FieldLabel>
           <select className="form-control" value={symbol} onChange={e => setSymbol(e.target.value)} disabled={loading}>
             {PAIRS.map(p => <option key={p} value={p}>{p}</option>)}
           </select>
         </div>
         <div className="form-group">
-          <label className="form-label">Interval</label>
+          <FieldLabel tooltip={FIELD_TIPS.interval}>Interval</FieldLabel>
           <select className="form-control" value={interval} onChange={e => setInterval(e.target.value)} disabled={loading}>
             {INTERVALS.map(iv => <option key={iv.value} value={iv.value}>{iv.label}</option>)}
           </select>
         </div>
         <div className="form-group">
-          <label className="form-label">Strategy</label>
+          <FieldLabel tooltip={FIELD_TIPS.strategy}>Strategy</FieldLabel>
           {strategies.length === 0 ? (
             <div style={{ padding: '8px 12px', background: 'var(--bg-input)', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)', color: 'var(--text-muted)', fontSize: '0.83rem' }}>
               Loading strategies…
@@ -105,10 +125,11 @@ export function ConfigForm({ strategies, onCreated }) {
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 'var(--space-3)' }}>
           {currentStrat.parameters.map(p => {
             const val = paramValues[p.name] !== undefined ? paramValues[p.name] : p.default
+            const tip = STRATEGY_PARAM_TIPS[p.name] ?? p.description ?? undefined
             if (p.type === 'bool') {
               return (
                 <div key={p.name} className="form-group">
-                  <label className="form-label">{p.name}</label>
+                  <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
                   <div className="toggle-group">
                     <button type="button" className={`toggle-option${val === true || val === 'true' ? ' active' : ''}`}
                       onClick={() => !loading && setParamValues(prev => ({ ...prev, [p.name]: true }))}>On</button>
@@ -121,7 +142,7 @@ export function ConfigForm({ strategies, onCreated }) {
             if (p.type === 'str') {
               return (
                 <div key={p.name} className="form-group">
-                  <label className="form-label">{p.name}</label>
+                  <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
                   <select className="form-control" value={val}
                     onChange={e => setParamValues(prev => ({ ...prev, [p.name]: e.target.value }))} disabled={loading}>
                     {['open_next', 'close_current'].map(o => <option key={o} value={o}>{o}</option>)}
@@ -131,7 +152,7 @@ export function ConfigForm({ strategies, onCreated }) {
             }
             return (
               <div key={p.name} className="form-group">
-                <label className="form-label">{p.name}</label>
+                <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
                 <input type="number" className="form-control" value={val}
                   min={p.min ?? undefined} max={p.max ?? undefined}
                   step={p.type === 'float' ? 0.001 : 1}
@@ -150,12 +171,12 @@ export function ConfigForm({ strategies, onCreated }) {
           <div className="section-title">Risk Parameters</div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-3)' }}>
             <div className="form-group">
-              <label className="form-label">Cost (bps)</label>
+              <FieldLabel tooltip={FIELD_TIPS.costBps}>Cost (bps)</FieldLabel>
               <input type="number" className="form-control" value={costBps} min={0} step={1}
                 onChange={e => setCostBps(parseFloat(e.target.value) || 0)} disabled={loading} />
             </div>
             <div className="form-group">
-              <label className="form-label" title="Maintenance margin used for the liquidation-price formula. Binance baseline ≈ 0.005 (0.5%) for low notional.">Maint. margin %</label>
+              <FieldLabel tooltip={FIELD_TIPS.maintenanceMargin}>Maint. margin %</FieldLabel>
               <input type="number" className="form-control" value={maintenanceMarginPct} min={0} step={0.001}
                 onChange={e => setMaintenanceMarginPct(parseFloat(e.target.value) || 0)} disabled={loading} />
             </div>

--- a/frontend/src/components/signals/RealTradesSection.jsx
+++ b/frontend/src/components/signals/RealTradesSection.jsx
@@ -1,9 +1,23 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
+import FieldLabel from '../FieldLabel'
 import { StatusBadge } from './ConfigBadge'
 import { PAIRS, fmtNum, fmtMoney } from './helpers'
 
 const FEE_WARN_PCT = 0.05
+
+const TIPS = {
+  simTradeId: 'ID del sim-trade que estás replicando con dinero real. Permite comparar slippage entre simulación y ejecución real (tab Compare).',
+  symbol: 'Par operado en el exchange.',
+  side: 'long: compraste primero. short: vendiste primero (margin/futures).',
+  entryPrice: 'Precio efectivo al que abriste la posición (después de fees de entrada si tu exchange los descuenta del precio).',
+  quantity: 'Cantidad de la criptomoneda base (no USDT). E.g. 0.1 BTC.',
+  fees: 'Fees totales de entrada en USD. Si los pones aquí no los pongas también dentro del PnL al cerrar.',
+  notes: 'Cualquier contexto que quieras retener: por qué tomaste el trade, condiciones del mercado, etc.',
+  exitPrice: 'Precio efectivo al que cerraste la posición.',
+  netPnl: 'PnL neto en USD (después de descontar fees del exchange). Si lo dejas en bruto, el sistema avisa si los fees implicados parecen anómalos.',
+  exitTime: 'Hora del cierre. Si la dejas vacía se usa "ahora".',
+}
 
 export function RealTradesSection() {
   const [realTrades, setRealTrades] = useState([])
@@ -125,19 +139,19 @@ export function RealTradesSection() {
         <div className="card" style={{ marginBottom: 'var(--space-4)', padding: 'var(--space-4)' }}>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(150px, 1fr))', gap: 'var(--space-3)' }}>
             <div className="form-group">
-              <label className="form-label">Link to SimTrade ID</label>
+              <FieldLabel tooltip={TIPS.simTradeId}>Link to SimTrade ID</FieldLabel>
               <input type="number" className="form-control" value={form.sim_trade_id}
                 onChange={e => setForm(prev => ({ ...prev, sim_trade_id: e.target.value }))} placeholder="Optional" />
             </div>
             <div className="form-group">
-              <label className="form-label">Symbol</label>
+              <FieldLabel tooltip={TIPS.symbol}>Symbol</FieldLabel>
               <select className="form-control" value={form.symbol}
                 onChange={e => setForm(prev => ({ ...prev, symbol: e.target.value }))}>
                 {PAIRS.map(p => <option key={p} value={p}>{p}</option>)}
               </select>
             </div>
             <div className="form-group">
-              <label className="form-label">Side</label>
+              <FieldLabel tooltip={TIPS.side}>Side</FieldLabel>
               <select className="form-control" value={form.side}
                 onChange={e => setForm(prev => ({ ...prev, side: e.target.value }))}>
                 <option value="long">Long</option>
@@ -145,23 +159,23 @@ export function RealTradesSection() {
               </select>
             </div>
             <div className="form-group">
-              <label className="form-label">Entry Price</label>
+              <FieldLabel tooltip={TIPS.entryPrice} required>Entry Price</FieldLabel>
               <input type="number" className="form-control" value={form.entry_price} step="0.01"
                 onChange={e => setForm(prev => ({ ...prev, entry_price: e.target.value }))} />
             </div>
             <div className="form-group">
-              <label className="form-label">Quantity</label>
+              <FieldLabel tooltip={TIPS.quantity} required>Quantity</FieldLabel>
               <input type="number" className="form-control" value={form.quantity} step="0.0001"
                 onChange={e => setForm(prev => ({ ...prev, quantity: e.target.value }))} />
             </div>
             <div className="form-group">
-              <label className="form-label">Fees</label>
+              <FieldLabel tooltip={TIPS.fees}>Fees</FieldLabel>
               <input type="number" className="form-control" value={form.fees} step="0.01"
                 onChange={e => setForm(prev => ({ ...prev, fees: e.target.value }))} />
             </div>
           </div>
           <div className="form-group" style={{ marginTop: 'var(--space-3)' }}>
-            <label className="form-label">Notes</label>
+            <FieldLabel tooltip={TIPS.notes}>Notes</FieldLabel>
             <input type="text" className="form-control" value={form.notes}
               onChange={e => setForm(prev => ({ ...prev, notes: e.target.value }))} placeholder="Optional notes" />
           </div>
@@ -237,25 +251,25 @@ export function RealTradesSection() {
                         <td colSpan={11} style={{ padding: 'var(--space-3)' }}>
                           <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'flex-end', flexWrap: 'wrap' }}>
                             <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.75rem' }}>Exit Price *</label>
+                              <FieldLabel tooltip={TIPS.exitPrice} required style={{ fontSize: '0.75rem' }}>Exit Price</FieldLabel>
                               <input type="number" className="form-control" step="0.01" style={{ width: 130 }}
                                 value={closeForm.exit_price}
                                 onChange={e => setCloseForm(prev => ({ ...prev, exit_price: e.target.value }))} />
                             </div>
                             <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.75rem' }}>Net PnL *</label>
+                              <FieldLabel tooltip={TIPS.netPnl} required style={{ fontSize: '0.75rem' }}>Net PnL</FieldLabel>
                               <input type="number" className="form-control" step="0.01" style={{ width: 130 }}
                                 value={closeForm.pnl}
                                 onChange={e => setCloseForm(prev => ({ ...prev, pnl: e.target.value }))} />
                             </div>
                             <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.75rem' }}>Exit Time</label>
+                              <FieldLabel tooltip={TIPS.exitTime} style={{ fontSize: '0.75rem' }}>Exit Time</FieldLabel>
                               <input type="datetime-local" className="form-control" style={{ width: 190 }}
                                 value={closeForm.exit_time}
                                 onChange={e => setCloseForm(prev => ({ ...prev, exit_time: e.target.value }))} />
                             </div>
                             <div className="form-group" style={{ marginBottom: 0 }}>
-                              <label className="form-label" style={{ fontSize: '0.75rem' }}>Notes</label>
+                              <FieldLabel tooltip={TIPS.notes} style={{ fontSize: '0.75rem' }}>Notes</FieldLabel>
                               <input type="text" className="form-control" style={{ width: 160 }}
                                 value={closeForm.notes} placeholder="Optional"
                                 onChange={e => setCloseForm(prev => ({ ...prev, notes: e.target.value }))} />


### PR DESCRIPTION
## Summary

Avanza #61 atendiendo el comentario nuevo: tooltips con icono \`?\` al lado de los field names para usuarios no-experts.

**Stacked sobre #119** (split SignalsPanel). Cuando #119 mergee, este PR hará rebase a develop automáticamente.

## Cambios

- **Nuevo \`frontend/src/components/FieldLabel.jsx\`**: primitive reusable. Props: \`children\`, \`tooltip\`, \`required\`, \`htmlFor\`, \`style\`. Usa el mismo CSS \`.param-help-wrap\` / \`.param-tooltip\` que ya existía para BacktestPanel.
- **\`BacktestPanel.jsx\`**: \`ParamLabel\` se simplifica a thin wrapper sobre \`FieldLabel\` (mantiene \`PARAM_META\` específico de backtest).
- **\`DataManager.jsx\`**: tooltips en \`Trading Pair\`, \`Interval\`, \`Start Date\`, \`End Date\`.
- **\`ConfigForm.jsx\`** (signals): tooltips en \`Pair\`, \`Interval\`, \`Strategy\`, parámetros de estrategia (\`reversal_pct\`, \`N_entrada\`, \`M_salida\`, \`stop_pct\`, \`modo_ejecucion\`, \`habilitar_long/short\`), \`Cost (bps)\`, \`Maint. margin %\`.
- **\`CapitalConfig.jsx\`** (signals): tooltips en \`Portfolio\`, \`Leverage\`, \`Invested Amount\`.
- **\`RealTradesSection.jsx\`** (signals): tooltips en todos los campos del form de creación + del form de close (\`Exit Price\`, \`Net PnL\`, \`Exit Time\`, \`Notes\`).

Los textos son contextuales al código actual (mencionan invariantes ya documentadas en \`CLAUDE.md\`: \`current_portfolio\` vs \`initial_portfolio\` post-#48, fórmula de liquidación post-#50, \`modo_ejecucion\` post-#58 Gap 2).

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] Smoke manual: hover sobre cada \`?\` en local — confirmar que el popover aparece encima/al lado y no se sale del viewport
- [ ] Verificar que \`Required\` (asterisco rojo) sale para Entry Price, Quantity, Net PnL en RealTrades
- [ ] Verificar que BacktestPanel sigue funcionando idéntico tras pasar \`ParamLabel\` por \`FieldLabel\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)