### PR TITLE
feat(frontend): skeleton/empty/toast components for tables and feedback (#61 eje 5)

### DIFF
--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -1,0 +1,10 @@
+export default function EmptyState({ icon, title, description, action, style }) {
+  return (
+    <div className="empty-state" role="status" style={style}>
+      {icon && <div className="empty-state-icon" aria-hidden="true">{icon}</div>}
+      {title && <div className="empty-state-title">{title}</div>}
+      {description && <div className="empty-state-text">{description}</div>}
+      {action}
+    </div>
+  )
+}

--- a/frontend/src/components/Skeleton.jsx
+++ b/frontend/src/components/Skeleton.jsx
@@ -1,0 +1,24 @@
+export default function Skeleton({ rows = 3, height, width = '100%', style }) {
+  if (rows === 1) {
+    return (
+      <span
+        className="skeleton"
+        aria-hidden="true"
+        style={{ display: 'inline-block', height: height ?? '1em', width, ...style }}
+      />
+    )
+  }
+  return (
+    <div role="status" aria-live="polite" aria-busy="true" style={style}>
+      <span className="visually-hidden" style={{ position: 'absolute', left: -9999 }}>Loading…</span>
+      {Array.from({ length: rows }).map((_, i) => (
+        <span
+          key={i}
+          className="skeleton skeleton-row"
+          aria-hidden="true"
+          style={{ height: height ?? 20, width }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/ToastContext.js
+++ b/frontend/src/components/ToastContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react'
+
+export const ToastContext = createContext(null)

--- a/frontend/src/components/ToastProvider.jsx
+++ b/frontend/src/components/ToastProvider.jsx
@@ -1,0 +1,72 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { ToastContext } from './ToastContext'
+
+const ICONS = { error: '⚠', warning: '⚠', success: '✓', info: 'ℹ' }
+const DEFAULT_DURATION_MS = 4000
+
+export function ToastProvider({ children }) {
+  const [items, setItems] = useState([])
+  const idRef = useRef(0)
+  const timersRef = useRef(new Map())
+
+  const dismiss = useCallback((id) => {
+    setItems(prev => prev.filter(t => t.id !== id))
+    const timer = timersRef.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timersRef.current.delete(id)
+    }
+  }, [])
+
+  const show = useCallback((message, variant = 'info', durationMs = DEFAULT_DURATION_MS) => {
+    idRef.current += 1
+    const id = idRef.current
+    setItems(prev => [...prev, { id, message, variant }])
+    if (durationMs > 0) {
+      const timer = setTimeout(() => dismiss(id), durationMs)
+      timersRef.current.set(id, timer)
+    }
+    return id
+  }, [dismiss])
+
+  useEffect(() => {
+    const timers = timersRef.current
+    return () => {
+      for (const t of timers.values()) clearTimeout(t)
+      timers.clear()
+    }
+  }, [])
+
+  const api = {
+    show,
+    dismiss,
+    error: (msg, ms) => show(msg, 'error', ms),
+    warning: (msg, ms) => show(msg, 'warning', ms),
+    success: (msg, ms) => show(msg, 'success', ms),
+    info: (msg, ms) => show(msg, 'info', ms),
+  }
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <div className="toast-container" aria-live="polite" aria-atomic="false">
+        {items.map(t => (
+          <div
+            key={t.id}
+            className={`toast-item toast-item--${t.variant}`}
+            role={t.variant === 'error' ? 'alert' : 'status'}
+          >
+            <span className="toast-item__icon" aria-hidden="true">{ICONS[t.variant] ?? ICONS.info}</span>
+            <span className="toast-item__body">{t.message}</span>
+            <button
+              type="button"
+              className="toast-item__close"
+              aria-label="Dismiss notification"
+              onClick={() => dismiss(t.id)}
+            >×</button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  )
+}

--- a/frontend/src/components/signals/ConfigForm.jsx
+++ b/frontend/src/components/signals/ConfigForm.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
 import FieldLabel from '../FieldLabel'
+import { useToast } from '../useToast'
 import { PAIRS, INTERVALS } from './helpers'
 import { CapitalConfig } from './CapitalConfig'
 
@@ -36,6 +37,7 @@ export function ConfigForm({ strategies, onCreated }) {
   const [capitalMode, setCapitalMode] = useState('leverage')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
+  const toast = useToast()
 
   useEffect(() => {
     if (strategies.length > 0 && !selectedStrat) {
@@ -81,12 +83,16 @@ export function ConfigForm({ strategies, onCreated }) {
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        setError(err.detail ?? `HTTP ${res.status}`)
+        const msg = err.detail ?? `HTTP ${res.status}`
+        setError(msg)
+        toast.error(`Failed to create config: ${msg}`)
         return
       }
+      toast.success(`Signal config created for ${symbol} ${interval}`)
       onCreated()
     } catch (e) {
       setError(e.message)
+      toast.error(`Network error: ${e.message}`)
     } finally {
       setLoading(false)
     }

--- a/frontend/src/components/signals/ConfigsList.jsx
+++ b/frontend/src/components/signals/ConfigsList.jsx
@@ -1,9 +1,16 @@
 import { ToggleSwitch } from './ToggleSwitch'
+import EmptyState from '../EmptyState'
 import { fmtMoney } from './helpers'
 
 export function ConfigsList({ configs, onToggle, onToggleTelegram, onDelete, onResetEquity }) {
   if (!configs || configs.length === 0) {
-    return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem', padding: 'var(--space-3)' }}>No signal configs yet.</div>
+    return (
+      <EmptyState
+        icon="⚙️"
+        title="No signal configs yet"
+        description="Crea una configuración abajo para que el motor empiece a evaluar señales."
+      />
+    )
   }
 
   return (

--- a/frontend/src/components/signals/RealTradesSection.jsx
+++ b/frontend/src/components/signals/RealTradesSection.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
 import FieldLabel from '../FieldLabel'
+import EmptyState from '../EmptyState'
+import { useToast } from '../useToast'
 import { StatusBadge } from './ConfigBadge'
 import { PAIRS, fmtNum, fmtMoney } from './helpers'
 
@@ -30,6 +32,7 @@ export function RealTradesSection() {
   const [closeForm, setCloseForm] = useState({ exit_price: '', pnl: '', exit_time: '', notes: '' })
   const [closeError, setCloseError] = useState(null)
   const [justClosedId, setJustClosedId] = useState(null)
+  const toast = useToast()
 
   const fetchRealTrades = useCallback(async () => {
     try {
@@ -105,7 +108,9 @@ export function RealTradesSection() {
       if (!res.ok) {
         let detail = `HTTP ${res.status}`
         try { const j = await res.json(); if (j?.detail) detail = j.detail } catch { /* non-JSON body */ }
-        setCloseError(`Close failed: ${detail}`)
+        const msg = `Close failed: ${detail}`
+        setCloseError(msg)
+        toast.error(msg)
         return
       }
       await fetchRealTrades()
@@ -113,8 +118,11 @@ export function RealTradesSection() {
       setCloseForm({ exit_price: '', pnl: '', exit_time: '', notes: '' })
       setJustClosedId(trade.id)
       setTimeout(() => setJustClosedId(prev => (prev === trade.id ? null : prev)), 1500)
+      toast.success(`Real trade #${trade.id} closed`)
     } catch (e) {
-      setCloseError(e?.message || 'Network error closing trade')
+      const msg = e?.message || 'Network error closing trade'
+      setCloseError(msg)
+      toast.error(msg)
     } finally {
       setLoading(false)
     }
@@ -187,7 +195,11 @@ export function RealTradesSection() {
       )}
 
       {realTrades.length === 0 ? (
-        <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>No real trades registered.</div>
+        <EmptyState
+          icon="💵"
+          title="No real trades registered"
+          description="Cuando ejecutes un trade real en tu exchange, regístralo aquí para comparar con el sim trade equivalente."
+        />
       ) : (
         <div style={{ overflowX: 'auto' }}>
           <table className="trade-table">

--- a/frontend/src/components/signals/SignalsList.jsx
+++ b/frontend/src/components/signals/SignalsList.jsx
@@ -1,9 +1,16 @@
 import { ConfigBadge, StatusBadge } from './ConfigBadge'
+import EmptyState from '../EmptyState'
 import { fmtNum, fmtTime, fmtIso } from './helpers'
 
 export function SignalsList({ signals }) {
   if (!signals || signals.length === 0) {
-    return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem', padding: 'var(--space-3)' }}>No signals generated yet.</div>
+    return (
+      <EmptyState
+        icon="📡"
+        title="No signals generated yet"
+        description="El motor genera señales cuando una vela cierra cumpliendo las condiciones de la estrategia. Suele tardar al menos un cierre completo del intervalo configurado."
+      />
+    )
   }
   return (
     <div>

--- a/frontend/src/components/signals/SimTradesList.jsx
+++ b/frontend/src/components/signals/SimTradesList.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
 import TradeReviewChart from '../TradeReviewChart'
+import EmptyState from '../EmptyState'
+import Skeleton from '../Skeleton'
 import { ConfigBadge, StatusBadge } from './ConfigBadge'
 import { fmtNum, fmtMoney } from './helpers'
 
@@ -49,7 +51,13 @@ export function SimTradesList({ trades, onClose }) {
   }, [expandedId, movesByTrade])
 
   if (!trades || trades.length === 0) {
-    return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem', padding: 'var(--space-3)' }}>No sim trades yet.</div>
+    return (
+      <EmptyState
+        icon="📊"
+        title="No sim trades yet"
+        description="Activa una configuración en Configurations y espera a que el motor de señales abra un trade simulado."
+      />
+    )
   }
 
   const detailed = viewMode === 'detailed'
@@ -250,7 +258,14 @@ function SimTradeReview({ trade, moves, loadingMoves }) {
 }
 
 function StopMovesDetail({ moves, loading }) {
-  if (loading) return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>Loading stop moves…</div>
+  if (loading) {
+    return (
+      <div>
+        <div style={{ fontWeight: 600, marginBottom: 'var(--space-2)' }}>Stop moves</div>
+        <Skeleton rows={3} />
+      </div>
+    )
+  }
   if (!moves || moves.length === 0) {
     return <div style={{ color: 'var(--text-muted)', fontSize: '0.85rem' }}>No stop moves for this trade.</div>
   }

--- a/frontend/src/components/useToast.js
+++ b/frontend/src/components/useToast.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { ToastContext } from './ToastContext'
+
+const NOOP = () => {}
+const FALLBACK = { show: NOOP, dismiss: NOOP, error: NOOP, warning: NOOP, success: NOOP, info: NOOP }
+
+export function useToast() {
+  const ctx = useContext(ToastContext)
+  return ctx ?? FALLBACK
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -575,6 +575,90 @@ select.form-control option {
   font-feature-settings: 'tnum' 1;
 }
 
+/* ---- Skeleton placeholder ---- */
+.skeleton {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    var(--bg-elevated) 0%,
+    var(--border-subtle) 50%,
+    var(--bg-elevated) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: var(--radius-sm);
+  animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton { animation: none; opacity: 0.6; }
+}
+
+.skeleton-row {
+  height: 20px;
+  margin: var(--space-2) 0;
+}
+
+/* ---- Toast ---- */
+.toast-container {
+  position: fixed;
+  bottom: var(--space-4);
+  right: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.toast-item {
+  pointer-events: auto;
+  min-width: 260px;
+  max-width: 420px;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-default);
+  background: var(--bg-card);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  animation: toast-slide-in 200ms ease-out;
+}
+
+@keyframes toast-slide-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .toast-item { animation: none; }
+}
+
+.toast-item--error { border-color: var(--color-danger); background: rgba(239, 68, 68, 0.08); }
+.toast-item--warning { border-color: var(--color-warning); background: rgba(234, 179, 8, 0.08); }
+.toast-item--success { border-color: var(--color-success); background: rgba(34, 197, 94, 0.08); }
+.toast-item--info { border-color: var(--color-info, var(--border-strong)); }
+
+.toast-item__icon { font-size: 1rem; line-height: 1.2; flex-shrink: 0; }
+.toast-item__body { flex: 1; line-height: 1.4; }
+.toast-item__close {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  font-size: 1rem;
+}
+.toast-item__close:hover { color: var(--text-primary); }
+
 /* ---- Sticky table headers ---- */
 .trade-table--sticky thead tr {
   position: sticky;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import { AuthProvider } from './auth/AuthProvider'
+import { ToastProvider } from './components/ToastProvider'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AuthProvider>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
     </AuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary

Avanza #61 (eje 5 — loading/empty/error states). Introduce tres primitives reusables y aplica donde la UX era flojita.

**Stacked sobre #121** (table density). Cuando #119/#120/#121 mergeen, este PR rebase.

## Componentes nuevos

- **\`<EmptyState icon title description action />\`** — wrapper sobre la clase \`.empty-state\` que ya existía en \`index.css\`. Sustituye 5 divs inline "No X yet" (SimTradesList, ConfigsList, SignalsList, RealTradesSection, etc.) por un componente con copy útil.
- **\`<Skeleton rows />\`** — shimmer placeholder para tablas/listas durante fetch. Honora \`prefers-reduced-motion\`. Usado en \`StopMovesDetail\` cuando carga el historial.
- **\`<ToastProvider>\` + \`useToast()\`** — queue de toasts vía Context. Variantes \`error|warning|success|info\`, auto-dismiss 4s, stack bottom-right. \`role="alert"\` para errores (screen readers). Wired en \`main.jsx\`.

\`useToast\` y \`ToastContext\` viven en archivos propios (\`useToast.js\`, \`ToastContext.js\`) para no romper la regla \`react-refresh/only-export-components\`.

## Aplicación

- **EmptyState** en SimTradesList, ConfigsList, SignalsList, RealTradesSection — copy contextual ("Activa una config y espera...", "Crea una configuración abajo...", etc.) en lugar de un div gris.
- **Skeleton** en StopMovesDetail mientras carga el historial de stop moves.
- **Toast** en \`ConfigForm.handleCreate\` (success al crear / error con detail) y en \`RealTradesSection.handleClose\` (success al cerrar trade / error con detail). Los inline errors se mantienen como anchor visible cerca del form para que no se pierdan.

## CSS añadido

- \`.skeleton\` + \`@keyframes skeleton-shimmer\` (con fallback \`prefers-reduced-motion\`)
- \`.toast-container\`, \`.toast-item\` + variantes color, \`@keyframes toast-slide-in\`, \`.toast-item__icon\`/\`__body\`/\`__close\`

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] En local con backend parado, crear una config → toast rojo "Network error: ..."
- [ ] Crear una config válida → toast verde "Signal config created..."
- [ ] Borrar todos los configs → ver EmptyState con icono ⚙️
- [ ] Expandir un sim_trade → mientras carga stop-moves, ver Skeleton; cuando termina, render normal
- [ ] Verificar prefers-reduced-motion en DevTools → skeleton sin animación

🤖 Generated with [Claude Code](https://claude.com/claude-code)