### PR TITLE
feat(frontend): ConfigForm 3-step wizard (#61 eje 4)

### DIFF
--- a/frontend/src/components/signals/ConfigForm.jsx
+++ b/frontend/src/components/signals/ConfigForm.jsx
@@ -1,8 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { apiFetch } from '../../auth/apiFetch'
 import FieldLabel from '../FieldLabel'
 import { useToast } from '../useToast'
-import { PAIRS, INTERVALS } from './helpers'
+import { PAIRS, INTERVALS, fmtMoney } from './helpers'
 import { CapitalConfig } from './CapitalConfig'
 
 const STRATEGY_PARAM_TIPS = {
@@ -24,7 +24,30 @@ const FIELD_TIPS = {
   maintenanceMargin: 'Margen de mantenimiento usado para calcular el precio de liquidación. Binance baseline ≈ 0.005 (0.5%) para notional bajo.',
 }
 
+const STEPS = [
+  { id: 1, label: 'Strategy & symbol' },
+  { id: 2, label: 'Capital & risk' },
+  { id: 3, label: 'Confirm' },
+]
+
+function StepIndicator({ step }) {
+  return (
+    <ol className="wizard-steps" aria-label="Form progress">
+      {STEPS.map(s => {
+        const cls = s.id === step ? 'wizard-step--active' : (s.id < step ? 'wizard-step--done' : '')
+        return (
+          <li key={s.id} className={`wizard-step ${cls}`} aria-current={s.id === step ? 'step' : undefined}>
+            <span className="wizard-step__num" aria-hidden="true">{s.id < step ? '✓' : s.id}</span>
+            <span>{s.label}</span>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
 export function ConfigForm({ strategies, onCreated }) {
+  const [step, setStep] = useState(1)
   const [symbol, setSymbol] = useState('BTCUSDT')
   const [interval, setInterval] = useState('1d')
   const [selectedStrat, setSelectedStrat] = useState('')
@@ -62,6 +85,26 @@ export function ConfigForm({ strategies, onCreated }) {
 
   const currentStrat = strategies.find(s => s.name === selectedStrat)
 
+  const step1Valid = !!selectedStrat
+  const step2Valid =
+    portfolio > 0 &&
+    maintenanceMarginPct >= 0 &&
+    costBps >= 0 &&
+    (capitalMode === 'leverage' ? leverage > 0 : investedAmount > 0)
+
+  const summary = useMemo(() => ({
+    Symbol: symbol,
+    Interval: INTERVALS.find(i => i.value === interval)?.label ?? interval,
+    Strategy: selectedStrat,
+    Params: Object.entries(paramValues).map(([k, v]) => `${k}=${v}`).join(', ') || '—',
+    'Cost (bps)': costBps,
+    'Maint. margin %': maintenanceMarginPct,
+    Portfolio: fmtMoney(portfolio),
+    ...(capitalMode === 'leverage'
+      ? { Leverage: leverage > 1 ? `${leverage}× (liquidación calculada)` : `${leverage}× (sin apalancamiento)` }
+      : { 'Invested amount': fmtMoney(investedAmount) }),
+  }), [symbol, interval, selectedStrat, paramValues, costBps, maintenanceMarginPct, portfolio, leverage, investedAmount, capitalMode])
+
   const handleCreate = async () => {
     setLoading(true)
     setError(null)
@@ -89,6 +132,7 @@ export function ConfigForm({ strategies, onCreated }) {
         return
       }
       toast.success(`Signal config created for ${symbol} ${interval}`)
+      setStep(1)
       onCreated()
     } catch (e) {
       setError(e.message)
@@ -100,105 +144,127 @@ export function ConfigForm({ strategies, onCreated }) {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-3)' }}>
-        <div className="form-group">
-          <FieldLabel tooltip={FIELD_TIPS.pair}>Pair</FieldLabel>
-          <select className="form-control" value={symbol} onChange={e => setSymbol(e.target.value)} disabled={loading}>
-            {PAIRS.map(p => <option key={p} value={p}>{p}</option>)}
-          </select>
-        </div>
-        <div className="form-group">
-          <FieldLabel tooltip={FIELD_TIPS.interval}>Interval</FieldLabel>
-          <select className="form-control" value={interval} onChange={e => setInterval(e.target.value)} disabled={loading}>
-            {INTERVALS.map(iv => <option key={iv.value} value={iv.value}>{iv.label}</option>)}
-          </select>
-        </div>
-        <div className="form-group">
-          <FieldLabel tooltip={FIELD_TIPS.strategy}>Strategy</FieldLabel>
-          {strategies.length === 0 ? (
-            <div style={{ padding: '8px 12px', background: 'var(--bg-input)', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)', color: 'var(--text-muted)', fontSize: '0.83rem' }}>
-              Loading strategies…
-            </div>
-          ) : (
-            <select className="form-control" value={selectedStrat} onChange={handleStrategyChange} disabled={loading}>
-              {strategies.map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
-            </select>
-          )}
-        </div>
-      </div>
+      <StepIndicator step={step} />
 
-      {currentStrat && currentStrat.parameters && currentStrat.parameters.length > 0 && (
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 'var(--space-3)' }}>
-          {currentStrat.parameters.map(p => {
-            const val = paramValues[p.name] !== undefined ? paramValues[p.name] : p.default
-            const tip = STRATEGY_PARAM_TIPS[p.name] ?? p.description ?? undefined
-            if (p.type === 'bool') {
-              return (
-                <div key={p.name} className="form-group">
-                  <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
-                  <div className="toggle-group">
-                    <button type="button" className={`toggle-option${val === true || val === 'true' ? ' active' : ''}`}
-                      onClick={() => !loading && setParamValues(prev => ({ ...prev, [p.name]: true }))}>On</button>
-                    <button type="button" className={`toggle-option${val === false || val === 'false' ? ' active' : ''}`}
-                      onClick={() => !loading && setParamValues(prev => ({ ...prev, [p.name]: false }))}>Off</button>
+      {step === 1 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-3)' }}>
+            <div className="form-group">
+              <FieldLabel tooltip={FIELD_TIPS.pair}>Pair</FieldLabel>
+              <select className="form-control" value={symbol} onChange={e => setSymbol(e.target.value)} disabled={loading}>
+                {PAIRS.map(p => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </div>
+            <div className="form-group">
+              <FieldLabel tooltip={FIELD_TIPS.interval}>Interval</FieldLabel>
+              <select className="form-control" value={interval} onChange={e => setInterval(e.target.value)} disabled={loading}>
+                {INTERVALS.map(iv => <option key={iv.value} value={iv.value}>{iv.label}</option>)}
+              </select>
+            </div>
+            <div className="form-group">
+              <FieldLabel tooltip={FIELD_TIPS.strategy}>Strategy</FieldLabel>
+              {strategies.length === 0 ? (
+                <div style={{ padding: '8px 12px', background: 'var(--bg-input)', border: '1px solid var(--border-default)', borderRadius: 'var(--radius-sm)', color: 'var(--text-muted)', fontSize: '0.83rem' }}>
+                  Loading strategies…
+                </div>
+              ) : (
+                <select className="form-control" value={selectedStrat} onChange={handleStrategyChange} disabled={loading}>
+                  {strategies.map(s => <option key={s.name} value={s.name}>{s.name}</option>)}
+                </select>
+              )}
+            </div>
+          </div>
+
+          {currentStrat && currentStrat.parameters && currentStrat.parameters.length > 0 && (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 'var(--space-3)' }}>
+              {currentStrat.parameters.map(p => {
+                const val = paramValues[p.name] !== undefined ? paramValues[p.name] : p.default
+                const tip = STRATEGY_PARAM_TIPS[p.name] ?? p.description ?? undefined
+                if (p.type === 'bool') {
+                  return (
+                    <div key={p.name} className="form-group">
+                      <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
+                      <div className="toggle-group">
+                        <button type="button" className={`toggle-option${val === true || val === 'true' ? ' active' : ''}`}
+                          onClick={() => !loading && setParamValues(prev => ({ ...prev, [p.name]: true }))}>On</button>
+                        <button type="button" className={`toggle-option${val === false || val === 'false' ? ' active' : ''}`}
+                          onClick={() => !loading && setParamValues(prev => ({ ...prev, [p.name]: false }))}>Off</button>
+                      </div>
+                    </div>
+                  )
+                }
+                if (p.type === 'str') {
+                  return (
+                    <div key={p.name} className="form-group">
+                      <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
+                      <select className="form-control" value={val}
+                        onChange={e => setParamValues(prev => ({ ...prev, [p.name]: e.target.value }))} disabled={loading}>
+                        {['open_next', 'close_current'].map(o => <option key={o} value={o}>{o}</option>)}
+                      </select>
+                    </div>
+                  )
+                }
+                return (
+                  <div key={p.name} className="form-group">
+                    <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
+                    <input type="number" className="form-control" value={val}
+                      min={p.min ?? undefined} max={p.max ?? undefined}
+                      step={p.type === 'float' ? 0.001 : 1}
+                      onChange={e => {
+                        const parsed = p.type === 'float' ? parseFloat(e.target.value) : parseInt(e.target.value, 10)
+                        setParamValues(prev => ({ ...prev, [p.name]: isNaN(parsed) ? e.target.value : parsed }))
+                      }} disabled={loading} />
                   </div>
-                </div>
-              )
-            }
-            if (p.type === 'str') {
-              return (
-                <div key={p.name} className="form-group">
-                  <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
-                  <select className="form-control" value={val}
-                    onChange={e => setParamValues(prev => ({ ...prev, [p.name]: e.target.value }))} disabled={loading}>
-                    {['open_next', 'close_current'].map(o => <option key={o} value={o}>{o}</option>)}
-                  </select>
-                </div>
-              )
-            }
-            return (
-              <div key={p.name} className="form-group">
-                <FieldLabel tooltip={tip}>{p.name}</FieldLabel>
-                <input type="number" className="form-control" value={val}
-                  min={p.min ?? undefined} max={p.max ?? undefined}
-                  step={p.type === 'float' ? 0.001 : 1}
-                  onChange={e => {
-                    const parsed = p.type === 'float' ? parseFloat(e.target.value) : parseInt(e.target.value, 10)
-                    setParamValues(prev => ({ ...prev, [p.name]: isNaN(parsed) ? e.target.value : parsed }))
-                  }} disabled={loading} />
-              </div>
-            )
-          })}
+                )
+              })}
+            </div>
+          )}
         </div>
       )}
 
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-4)' }}>
-        <div>
-          <div className="section-title">Risk Parameters</div>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-3)' }}>
-            <div className="form-group">
-              <FieldLabel tooltip={FIELD_TIPS.costBps}>Cost (bps)</FieldLabel>
-              <input type="number" className="form-control" value={costBps} min={0} step={1}
-                onChange={e => setCostBps(parseFloat(e.target.value) || 0)} disabled={loading} />
-            </div>
-            <div className="form-group">
-              <FieldLabel tooltip={FIELD_TIPS.maintenanceMargin}>Maint. margin %</FieldLabel>
-              <input type="number" className="form-control" value={maintenanceMarginPct} min={0} step={0.001}
-                onChange={e => setMaintenanceMarginPct(parseFloat(e.target.value) || 0)} disabled={loading} />
+      {step === 2 && (
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-4)' }}>
+          <div>
+            <div className="section-title">Risk parameters</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-3)' }}>
+              <div className="form-group">
+                <FieldLabel tooltip={FIELD_TIPS.costBps}>Cost (bps)</FieldLabel>
+                <input type="number" className="form-control" value={costBps} min={0} step={1}
+                  onChange={e => setCostBps(parseFloat(e.target.value) || 0)} disabled={loading} />
+              </div>
+              <div className="form-group">
+                <FieldLabel tooltip={FIELD_TIPS.maintenanceMargin}>Maint. margin %</FieldLabel>
+                <input type="number" className="form-control" value={maintenanceMarginPct} min={0} step={0.001}
+                  onChange={e => setMaintenanceMarginPct(parseFloat(e.target.value) || 0)} disabled={loading} />
+              </div>
             </div>
           </div>
+          <div>
+            <div className="section-title">Capital</div>
+            <CapitalConfig
+              portfolio={portfolio} setPortfolio={setPortfolio}
+              leverage={leverage} setLeverage={setLeverage}
+              investedAmount={investedAmount} setInvestedAmount={setInvestedAmount}
+              mode={capitalMode} setMode={setCapitalMode}
+              disabled={loading}
+            />
+          </div>
         </div>
-        <div>
-          <div className="section-title">Capital</div>
-          <CapitalConfig
-            portfolio={portfolio} setPortfolio={setPortfolio}
-            leverage={leverage} setLeverage={setLeverage}
-            investedAmount={investedAmount} setInvestedAmount={setInvestedAmount}
-            mode={capitalMode} setMode={setCapitalMode}
-            disabled={loading}
-          />
+      )}
+
+      {step === 3 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+          <div className="section-title">Review and confirm</div>
+          <dl className="wizard-summary">
+            {Object.entries(summary).map(([k, v]) => (
+              <div key={k} style={{ display: 'contents' }}>
+                <dt>{k}</dt>
+                <dd>{v}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
-      </div>
+      )}
 
       {error && (
         <div style={{
@@ -208,10 +274,28 @@ export function ConfigForm({ strategies, onCreated }) {
         }}>{error}</div>
       )}
 
-      <div>
-        <button className="btn btn-primary" onClick={handleCreate} disabled={loading || !selectedStrat}>
-          {loading ? 'Creating…' : 'Create Signal Config'}
-        </button>
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 'var(--space-2)', flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          className="btn btn-secondary"
+          onClick={() => setStep(s => Math.max(1, s - 1))}
+          disabled={step === 1 || loading}
+        >← Back</button>
+        {step < 3 ? (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => setStep(s => Math.min(3, s + 1))}
+            disabled={(step === 1 && !step1Valid) || (step === 2 && !step2Valid) || loading}
+          >Next →</button>
+        ) : (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleCreate}
+            disabled={loading || !step1Valid || !step2Valid}
+          >{loading ? 'Creating…' : 'Create signal config'}</button>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -708,6 +708,73 @@ select.form-control option {
 .empty-state-title { font-size: 0.9rem; font-weight: 500; color: var(--text-secondary); }
 .empty-state-text  { font-size: 0.8rem; max-width: 320px; }
 
+/* ---- Wizard step indicator ---- */
+.wizard-steps {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.wizard-step {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  flex: 1 1 0;
+  min-width: 140px;
+}
+
+.wizard-step__num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--border-strong);
+  color: var(--text-secondary);
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.wizard-step--active {
+  background: var(--bg-card);
+  border-color: var(--color-success);
+  color: var(--text-primary);
+}
+.wizard-step--active .wizard-step__num {
+  background: var(--color-success);
+  color: var(--bg-base);
+}
+
+.wizard-step--done {
+  color: var(--text-secondary);
+}
+.wizard-step--done .wizard-step__num {
+  background: var(--color-success);
+  color: var(--bg-base);
+}
+
+.wizard-summary {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--space-2) var(--space-4);
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-elevated);
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+}
+.wizard-summary dt { color: var(--text-muted); }
+.wizard-summary dd { color: var(--text-primary); margin: 0; font-family: var(--font-mono); }
+
 /* ---- Toggle group ---- */
 .toggle-group {
   display: flex;


### PR DESCRIPTION
## Summary

Avanza #61 (eje 4 — wizard ConfigForm). El form monolítico se divide en 3 pasos para reducir la fricción del primer uso.

## Pasos

1. **Strategy & symbol** — pair, interval, strategy, strategy params (con sus tooltips)
2. **Capital & risk** — cost bps, maint. margin %, portfolio + leverage/invested
3. **Confirm** — summary read-only de todos los campos, luego Create

## Validación

Cada paso valida antes de permitir avanzar:
- Step 1: estrategia seleccionada (los defaults cubren el resto)
- Step 2: \`portfolio > 0\`, costes/margen ≥ 0, capital > 0 según el modo
- Step 3: todos los anteriores + Create

## UX

- Indicador de progreso arriba (\`1 → 2 → 3\`) con done steps marcados ✓ y el activo resaltado en verde.
- Footer con Back / Next; en step 3 el botón cambia a Create.
- Toast de éxito al crear → resetea el wizard a step 1 para crear otra config.
- Toast de error → mantiene el step actual y muestra el detalle inline también.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] En local: avanzar paso a paso, verificar que Next se deshabilita si el step no valida (e.g. portfolio=0 en step 2)
- [ ] Step 3 muestra el resumen correcto (símbolo, leverage, etc.)
- [ ] Crear una config válida → toast verde + reset a step 1
- [ ] Crear con backend caído → toast rojo, queda en step 3 con el error inline
- [ ] Smoke en QA tras merge: tab Configurations carga, wizard navegable

🤖 Generated with [Claude Code](https://claude.com/claude-code)