### PR TITLE
feat(frontend): mobile/tablet support — hamburger nav + scroll affordance (#61 eje 7)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,12 @@ function App() {
   }, [isAdmin])
 
   const [activeTab, setActiveTab] = useState(isAdmin ? 'data' : 'signals')
+  const [navOpen, setNavOpen] = useState(false)
+
+  const selectTab = (id) => {
+    setActiveTab(id)
+    setNavOpen(false)
+  }
 
   // Loading state
   if (isLoading) {
@@ -63,12 +69,23 @@ function App() {
           </div>
         </div>
 
-        <nav className="tab-nav">
+        <button
+          type="button"
+          className="topbar-burger"
+          aria-label={navOpen ? 'Close navigation' : 'Open navigation'}
+          aria-expanded={navOpen}
+          aria-controls="primary-nav"
+          onClick={() => setNavOpen(o => !o)}
+        >
+          <span aria-hidden="true">{navOpen ? '✕' : '☰'}</span>
+        </button>
+
+        <nav id="primary-nav" className={`tab-nav${navOpen ? ' tab-nav--open' : ''}`}>
           {tabs.map(tab => (
             <button
               key={tab.id}
               className={`tab-btn${activeTab === tab.id ? ' active' : ''}`}
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => selectTab(tab.id)}
             >
               {tab.label}
             </button>
@@ -76,7 +93,7 @@ function App() {
         </nav>
 
         <div className="topbar-user">
-          <span style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginRight: 'var(--space-3)' }}>{username}</span>
+          <span className="topbar-username">{username}</span>
           <button
             onClick={logout}
             style={{

--- a/frontend/src/components/signals/ConfigsList.jsx
+++ b/frontend/src/components/signals/ConfigsList.jsx
@@ -14,7 +14,7 @@ export function ConfigsList({ configs, onToggle, onToggleTelegram, onDelete, onR
   }
 
   return (
-    <div style={{ overflowX: 'auto' }}>
+    <div className="trade-table-wrap">
       <table className="trade-table">
         <thead>
           <tr>

--- a/frontend/src/components/signals/RealTradesSection.jsx
+++ b/frontend/src/components/signals/RealTradesSection.jsx
@@ -201,7 +201,7 @@ export function RealTradesSection() {
           description="Cuando ejecutes un trade real en tu exchange, regístralo aquí para comparar con el sim trade equivalente."
         />
       ) : (
-        <div style={{ overflowX: 'auto' }}>
+        <div className="trade-table-wrap">
           <table className="trade-table">
             <thead>
               <tr>

--- a/frontend/src/components/signals/SignalsList.jsx
+++ b/frontend/src/components/signals/SignalsList.jsx
@@ -24,7 +24,7 @@ export function SignalsList({ signals }) {
         <strong style={{ color: 'var(--text-secondary)' }}>Stop (SL)</strong>: nivel de stop-loss para tu exchange — el sistema cierra aquí también el SimTrade.
       </div>
 
-      <div style={{ overflowX: 'auto' }}>
+      <div className="trade-table-wrap">
         <table className="trade-table">
           <thead>
             <tr>

--- a/frontend/src/components/signals/SimTradesList.jsx
+++ b/frontend/src/components/signals/SimTradesList.jsx
@@ -88,7 +88,7 @@ export function SimTradesList({ trades, onClose }) {
         </div>
       </div>
 
-      <div style={{ overflowX: 'auto', maxHeight: '70vh', overflowY: 'auto' }}>
+      <div className="trade-table-wrap" style={{ maxHeight: '70vh', overflowY: 'auto' }}>
         <table className="trade-table trade-table--sticky">
           <thead>
             <tr>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -376,6 +376,69 @@ select.form-control option {
   .main-content { padding: var(--space-4); }
 }
 
+/* ---- Mobile topbar (hamburger drawer) ---- */
+.topbar-burger {
+  display: none;
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-sm);
+  font-size: 1.1rem;
+  cursor: pointer;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.topbar-burger:hover { background: var(--bg-elevated); }
+
+.topbar-user {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.topbar-username {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-right: var(--space-3);
+}
+
+@media (max-width: 768px) {
+  .topbar { padding: 0 var(--space-4); gap: var(--space-3); }
+  .topbar-subtitle { display: none; }
+  .topbar-burger { display: inline-flex; align-items: center; justify-content: center; }
+  .topbar-username { display: none; }
+
+  /* Drawer-style nav: hidden by default, expands below the topbar when open */
+  .tab-nav {
+    display: none;
+    position: absolute;
+    top: 56px;
+    left: var(--space-4);
+    right: var(--space-4);
+    flex-direction: column;
+    padding: var(--space-2);
+    background: var(--bg-card);
+    border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-card);
+    z-index: 99;
+  }
+  .tab-nav--open { display: flex; }
+  .tab-nav .tab-btn { width: 100%; text-align: left; padding: var(--space-2) var(--space-3); }
+}
+
+/* ---- Table horizontal scroll affordance ---- */
+.trade-table-wrap {
+  position: relative;
+  overflow-x: auto;
+  /* Right-edge gradient hint that there's more content to scroll to.
+     Subtle on desktop; clearly visible on narrow viewports. */
+  background:
+    linear-gradient(to left, var(--bg-card), transparent 24px) right / 24px 100% no-repeat,
+    var(--bg-card);
+}
+
 /* ---- Flex helpers ---- */
 .flex { display: flex; }
 .flex-col { display: flex; flex-direction: column; }


### PR DESCRIPTION
## Summary

Cierra el último eje pendiente de #61 (eje 7 — mobile/tablet).

## Cambios

### Topbar colapsable < 768px

- Nuevo botón **\`☰\`** \`.topbar-burger\` (visible solo en mobile, hidden en desktop) con \`aria-expanded\` + \`aria-controls\`.
- \`.tab-nav\` cambia a un **drawer** posicionado absoluto debajo del topbar cuando se añade la clase \`.tab-nav--open\`.
- Botones de tab se apilan verticalmente y ocupan el ancho completo del drawer.
- Subtítulo "Laboratory" y el nombre de usuario se ocultan en mobile (logout sigue visible).
- Seleccionar un tab cierra el drawer automáticamente (handler \`selectTab\` — fuera de \`useEffect\` para no romper la regla \`react-hooks/set-state-in-effect\`).

### Affordance de scroll horizontal en tablas

- Nueva clase **\`.trade-table-wrap\`** sustituye el \`<div style={{ overflowX: 'auto' }}>\` inline en \`ConfigsList\`, \`SignalsList\`, \`SimTradesList\`, \`RealTradesSection\`.
- Añade un gradiente sutil en el borde derecho que indica "hay más contenido →" cuando la tabla excede el ancho del viewport. Discreto en desktop; útil en mobile.
- \`SimTradesList\` mantiene su \`maxHeight + overflowY\` inline para el sticky header (composición ortogonal con la nueva clase).

## Out of scope (intencional)

- **Columna sticky en tablas**: sería caro de implementar bien con la mezcla de columnas variables (compact vs detailed) y no es bloqueante. La affordance del gradiente cubre el caso de "no veo todas las columnas" para usuarios mobile.
- **DataManager**: usa una tabla con estilos inline propios (no \`.trade-table\`). Bajo uso en mobile (es admin-only para descargar candles), lo dejamos.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npm run build\` clean
- [ ] Smoke en local con DevTools responsive a 375px y 768px:
  - El hamburger aparece, abre el drawer, los tabs funcionan, seleccionar uno cierra el drawer
  - El gradiente del borde derecho de las tablas se ve
  - Las cards y el padding general escalan razonablemente
- [ ] Smoke en desktop (>1024px): no hay regresiones — hamburger no se ve, topbar igual que antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)