### PR TITLE
fix(backtest): equity chart x-axis renders real dates (#125)

### DIFF
--- a/backend/api/backtest_routes.py
+++ b/backend/api/backtest_routes.py
@@ -66,6 +66,7 @@ async def start_backtest(req: BacktestRequest) -> dict:
         "params": req.params,
         "initial_capital": req.initial_capital,
         "equity_curve": result.equity_curve,
+        "timestamps": result.timestamps,
         "trade_log": result.trade_log,
         "summary": result.summary,
         "liquidated": result.liquidated,

--- a/backend/backtest_engine.py
+++ b/backend/backtest_engine.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class BacktestResult:
     equity_curve: list[float] = field(default_factory=list)
+    timestamps: list[int] = field(default_factory=list)
     trade_log: list[dict] = field(default_factory=list)
     summary: dict = field(default_factory=dict)
     liquidated: bool = False
@@ -67,6 +68,7 @@ async def run_backtest(
 
     equity = initial_capital
     equity_curve: list[float] = []
+    timestamps: list[int] = []
     trade_log: list[dict] = []
     state = PositionState()
     pending_entry: Signal | None = None  # deferred to next open
@@ -239,6 +241,7 @@ async def run_backtest(
             if equity <= 0:
                 result.liquidated = True
                 result.equity_curve = equity_curve
+                result.timestamps = timestamps
                 result.trade_log = trade_log
                 interval_ms = INTERVAL_MS.get(interval, 86_400_000)
                 result.summary = compute_backtest_metrics(equity_curve, trade_log, initial_capital, interval_ms)
@@ -267,8 +270,10 @@ async def run_backtest(
         else:
             mtm_equity = equity
         equity_curve.append(mtm_equity)
+        timestamps.append(int(candle["open_time"]))
 
     result.equity_curve = equity_curve
+    result.timestamps = timestamps
     result.trade_log = trade_log
     interval_ms = INTERVAL_MS.get(interval, 86_400_000)
     result.summary = compute_backtest_metrics(equity_curve, trade_log, initial_capital, interval_ms)

--- a/frontend/src/components/BacktestPanel.jsx
+++ b/frontend/src/components/BacktestPanel.jsx
@@ -203,6 +203,7 @@ function ResultsView({ result, symbol, interval, startMs, endMs }) {
   if (!result) return null
 
   const equityCurve   = result.equity_curve            ?? []
+  const timestamps    = result.timestamps              ?? []
   const tradeLog      = result.trade_log               ?? []
   const drawdownCurve = result.summary?.drawdown_curve ?? []
 
@@ -247,7 +248,7 @@ function ResultsView({ result, symbol, interval, startMs, endMs }) {
         </a>
       </div>
 
-      {view === 'chart'  && <EquityChart equityCurve={equityCurve} drawdownCurve={drawdownCurve} />}
+      {view === 'chart'  && <EquityChart equityCurve={equityCurve} drawdownCurve={drawdownCurve} timestamps={timestamps} />}
       {view === 'trades' && <TradeLog trades={tradeLog} />}
       {view === 'review' && (
         <TradeReviewChart

--- a/frontend/src/components/EquityChart.jsx
+++ b/frontend/src/components/EquityChart.jsx
@@ -59,7 +59,7 @@ function DrawdownTooltip({ active, payload, label }) {
   )
 }
 
-export default function EquityChart({ equityCurve = [], drawdownCurve = [] }) {
+export default function EquityChart({ equityCurve = [], drawdownCurve = [], timestamps = [] }) {
   if (!equityCurve || equityCurve.length === 0) {
     return (
       <div className="empty-state">
@@ -70,9 +70,11 @@ export default function EquityChart({ equityCurve = [], drawdownCurve = [] }) {
     )
   }
 
-  // Both arrays are plain number[] — merge by index
+  // Merge by index. ``timestamps[i]`` is epoch_ms from the backtest engine; the
+  // ``?? i`` fallback only fires for legacy in-memory results that pre-date the
+  // timestamps field — those will render with broken dates until re-run.
   const chartData = equityCurve.map((eq, i) => ({
-    ts: i,
+    ts: timestamps[i] ?? i,
     equity: eq,
     drawdown: (drawdownCurve[i] ?? 0) / 100,  // backend returns pct, chart uses ratio
   }))

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -235,6 +235,42 @@ async def test_equity_curve_length_matches_candles(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_timestamps_length_matches_equity_curve(monkeypatch):
+    _patch_candles(monkeypatch, _build_flat_candles(n=50))
+
+    step = INTERVAL_MS["1d"]
+    result = await run_backtest(
+        symbol="BTCUSDT",
+        interval="1d",
+        start_ms=0,
+        end_ms=step * 50,
+        strategy_name="breakout",
+        params={"N_entrada": 20, "M_salida": 10, "stop_pct": 0.05},
+        initial_capital=10_000.0,
+    )
+    assert len(result.timestamps) == len(result.equity_curve)
+
+
+@pytest.mark.asyncio
+async def test_timestamps_match_candle_open_time(monkeypatch):
+    candles = _build_flat_candles(n=30)
+    _patch_candles(monkeypatch, candles)
+
+    step = INTERVAL_MS["1d"]
+    result = await run_backtest(
+        symbol="BTCUSDT",
+        interval="1d",
+        start_ms=0,
+        end_ms=step * 30,
+        strategy_name="breakout",
+        params={"N_entrada": 20, "M_salida": 10, "stop_pct": 0.05},
+        initial_capital=10_000.0,
+    )
+    expected = [int(c["open_time"]) for c in candles]
+    assert result.timestamps == expected
+
+
+@pytest.mark.asyncio
 async def test_bankruptcy_detection(monkeypatch):
     """For normal runs, liquidated should be False."""
     _patch_candles(monkeypatch, _build_trending_up_candles(n=60))


### PR DESCRIPTION
## Summary

- Adds `timestamps: list[int]` (epoch_ms, parallel to `equity_curve`) on `BacktestResult` and forwards it through the `/backtest` API.
- `EquityChart` now uses `timestamps[i]` instead of the array index, so the x-axis on the Equity Curve and Drawdown plots shows real candle dates instead of "Jan 1, 70".
- Two new backend tests assert `timestamps` length matches `equity_curve` and values match `df["open_time"]`.

Backwards-compatible: additive JSON field, fallback `?? i` in the chart preserves old behaviour for legacy in-memory results.

## Test plan

- [x] `pytest -q` (backend: 257 passed, 32 deselected — parity slow tests)
- [x] `ruff check backend/ tests/` and `ruff format --check`
- [x] `npm run lint` (frontend)
- [ ] Manual verify in dev/QA: run a backtest, x-axis on Equity & Drawdown shows real dates (e.g. `Oct 1, 25` … `Apr 28, 26`).

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)