### PR TITLE
chore(frontend): wizard cost cleanup + chart locale fallback (#127, #128)

### DIFF
--- a/frontend/src/components/TradeReviewChart.jsx
+++ b/frontend/src/components/TradeReviewChart.jsx
@@ -55,6 +55,12 @@ export default function TradeReviewChart({ symbol, interval, startMs, endMs, tra
           crosshair: {
             mode: 0,
           },
+          // Pin the locale so axis tick formatting never depends on
+          // navigator.language, which can be malformed in headless / test
+          // browsers and crash Intl.DateTimeFormat on every animation frame.
+          localization: {
+            locale: 'en-US',
+          },
           timeScale: {
             timeVisible: true,
             secondsVisible: false,

--- a/frontend/src/components/signals/ConfigForm.jsx
+++ b/frontend/src/components/signals/ConfigForm.jsx
@@ -84,6 +84,10 @@ export function ConfigForm({ strategies, onCreated }) {
   }
 
   const currentStrat = strategies.find(s => s.name === selectedStrat)
+  // Hide ``coste_total_bps`` from the wizard: it duplicates the Step 2 ``Cost (bps)``
+  // field, which is the live-equity source of truth. Persisted at submit-time as a
+  // mirror of ``costBps`` so the strategy params dict stays internally consistent.
+  const visibleParams = (currentStrat?.parameters ?? []).filter(p => p.name !== 'coste_total_bps')
 
   const step1Valid = !!selectedStrat
   const step2Valid =
@@ -96,7 +100,9 @@ export function ConfigForm({ strategies, onCreated }) {
     Symbol: symbol,
     Interval: INTERVALS.find(i => i.value === interval)?.label ?? interval,
     Strategy: selectedStrat,
-    Params: Object.entries(paramValues).map(([k, v]) => `${k}=${v}`).join(', ') || '—',
+    Params: Object.entries(paramValues)
+      .filter(([k]) => k !== 'coste_total_bps')
+      .map(([k, v]) => `${k}=${v}`).join(', ') || '—',
     'Cost (bps)': costBps,
     'Maint. margin %': maintenanceMarginPct,
     Portfolio: fmtMoney(portfolio),
@@ -111,7 +117,7 @@ export function ConfigForm({ strategies, onCreated }) {
     try {
       const body = {
         symbol, interval, strategy: selectedStrat,
-        params: paramValues,
+        params: { ...paramValues, coste_total_bps: costBps },
         cost_bps: costBps,
         maintenance_margin_pct: maintenanceMarginPct,
         initial_portfolio: portfolio,
@@ -175,9 +181,9 @@ export function ConfigForm({ strategies, onCreated }) {
             </div>
           </div>
 
-          {currentStrat && currentStrat.parameters && currentStrat.parameters.length > 0 && (
+          {currentStrat && visibleParams.length > 0 && (
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))', gap: 'var(--space-3)' }}>
-              {currentStrat.parameters.map(p => {
+              {visibleParams.map(p => {
                 const val = paramValues[p.name] !== undefined ? paramValues[p.name] : p.default
                 const tip = STRATEGY_PARAM_TIPS[p.name] ?? p.description ?? undefined
                 if (p.type === 'bool') {


### PR DESCRIPTION
## Summary

Two unrelated frontend nits batched together; reviewable per commit.

- **#127** (`chore(wizard): hide duplicate coste_total_bps...`) — the New Configuration wizard exposed `coste_total_bps` (Step 1 strategy param) and `Cost (bps)` (Step 2 config field) side-by-side in the Confirm summary, both defaulting to 10. Live trading reads only the config-level field, so the strategy param is dead weight in live mode. This PR hides it from the wizard editor + Confirm summary, and mirrors `costBps` into `params.coste_total_bps` on submit so the persisted record stays internally consistent. BacktestPanel (which uses the strategy param directly) is untouched.
- **#128** (`fix(charts): pin TradeReviewChart locale to en-US`) — `lightweight-charts` defaults to `navigator.language` for time-axis formatting; in headless/test browsers `navigator.language` can be malformed (literal `"undefined"`) and crash `Intl.DateTimeFormat` on every animation frame. Pin the locale so we never depend on it.

## Test plan

- [x] `npm run lint`
- [ ] Manual verify in dev/QA:
  - SignalsPanel → New configuration wizard: Step 1 strategy params do NOT show `coste_total_bps`. Confirm screen shows `Cost (bps): N` exactly once. After Create, persisted config has `cost_bps == params.coste_total_bps`.
  - BacktestPanel → run backtest → Review tab: no `RangeError: invalid language tag` in console under playwright-cli + Firefox.

Closes #127
Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)