### PR TITLE
fix(backtest): unblock event loop + bump pod resources (post-#132 follow-up)

### DIFF
--- a/backend/backtest_engine.py
+++ b/backend/backtest_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 
@@ -38,16 +39,34 @@ async def run_backtest(
 ) -> BacktestResult:
     """
     Run a backtest for a given symbol/interval/range using the specified strategy.
+
+    The async wrapper handles the DB read; the synchronous compute path runs in
+    a thread (``asyncio.to_thread``) so the event loop keeps serving /healthz
+    and other requests while the backtest is iterating candles. Without this
+    split, large backtests (≥10k candles, or any strategy with a Python loop in
+    init() like the zigzag-based ones) block the loop for tens of seconds and
+    trip the liveness probe → SIGKILL (post-#132).
     """
     result = BacktestResult()
 
-    # Load candles
     df = await load_candles_df(symbol, interval, start_ms, end_ms)
     if df.empty or len(df) < 2:
         result.error = "Insufficient candle data for backtest"
         return result
 
-    # Initialize strategy
+    return await asyncio.to_thread(_run_backtest_compute, df, interval, strategy_name, params, initial_capital)
+
+
+def _run_backtest_compute(
+    df: pd.DataFrame,
+    interval: str,
+    strategy_name: str,
+    params: dict,
+    initial_capital: float,
+) -> BacktestResult:
+    """Synchronous core: strategy init + candle iteration. Always run in a thread."""
+    result = BacktestResult()
+
     try:
         strategy = get_strategy(strategy_name)
         strategy.init(params, df)

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,22 +46,28 @@ spec:
                 name: {{ include "tradingtools.configmapName" . }}
             - secretRef:
                 name: {{ .Values.existingSecret }}
+          # Probe tolerances bumped post-#132. Even with run_backtest moved
+          # off the event loop via asyncio.to_thread, GC pauses and short
+          # bursts during init() of Python-loop-based strategies can briefly
+          # delay /healthz. The previous 5s × 3 = ~50s ceiling killed the pod
+          # under load; ~150s (30s × 5) is a safer envelope and still catches
+          # genuine hangs within a few minutes.
           livenessProbe:
             httpGet:
               path: /healthz
               port: http
             initialDelaySeconds: 10
-            periodSeconds: 15
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 30
+            timeoutSeconds: 30
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /readyz
               port: http
             initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            periodSeconds: 15
+            timeoutSeconds: 15
+            failureThreshold: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,12 +32,16 @@ config:
   CORS_ORIGINS: "*"
 
 resources:
+  # Bumped post-#132: backtests over multi-year intraday windows (10k+ candles)
+  # plus the new strategies push memory + CPU past the previous 512Mi/500m
+  # ceiling. The asyncio.to_thread split in run_backtest fixes the event-loop
+  # block, but the underlying compute still needs more headroom.
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 256Mi
   limits:
-    cpu: 500m
-    memory: 512Mi
+    cpu: 1000m
+    memory: 1Gi
 
 # Schedule app pods only on worker nodes by default. k3s does not taint
 # control-plane nodes, so without this hint the scheduler is happy to


### PR DESCRIPTION
## Summary

The backtest pod was crashing post-#135 deploy with SIGKILL (exit 137, looked like OOM but was actually liveness probe failure). Root cause: `run_backtest` is `async def` but its main candle-iteration loop is pure synchronous CPU work (pandas rolling, Wilder RMA, zigzag Python loop) with no `await`. For large windows (≥10k candles) or zigzag-based strategies the asyncio event loop is blocked for 30–60 s — `/healthz` can't respond → liveness probe times out 3× → pod killed.

The new `zigzag_momentum` strategy from #135 didn't introduce this — `support_resistance` already had the same shape — but it made it more visible at intraday windows where the new strategies shine.

## Fix

1. **`backend/backtest_engine.py`** — split `run_backtest`:
   - Async wrapper: awaits `load_candles_df` (DB read), then `await asyncio.to_thread(_run_backtest_compute, ...)`.
   - `_run_backtest_compute` (sync, private): all the strategy init + candle iteration + metrics. Identical body to the previous loop, just lifted into its own function. Public signature, return type, semantics unchanged.
2. **`helm/values.yaml`** — bump pod resources for headroom: memory limit 512Mi → 1Gi, CPU limit 500m → 1000m, requests bumped proportionally.
3. **`helm/templates/deployment.yaml`** — bump probe tolerances (~50s grace → ~150s): liveness period 15→30, timeout 5→30, failure 3→5; readiness similar.

## Test plan

- [x] `pytest -q` — 291 passed, 0 failed.
- [x] `pytest -m slow tests/integration/test_parity.py` (slot_a) — **14 cases pass** across all 7 strategies in both `close_current` and `open_next`. The to_thread wrap doesn't disturb backtest↔live trade-log equivalence.
- [x] `ruff check` + `ruff format --check` — clean.

## Verification after merge

Once Argo syncs the new chart on dev, run a heavy backtest (e.g. BTCUSDT 1h × 3 years with `donchian_adx_atr` defaults — ~26k candles) from the UI. Should complete without restarting the pod, and `/healthz` should keep responding throughout (test with `kubectl logs -f` watching for liveness probe warnings).

Refs: #132
🤖 Generated with [Claude Code](https://claude.com/claude-code)