### PR TITLE
feat(strategies): polish breakout & support_resistance trailing (4 opt-in flags)

### DIFF
--- a/backend/strategies/breakout.py
+++ b/backend/strategies/breakout.py
@@ -36,6 +36,14 @@ class BreakoutStrategy(Strategy):
                 None,
                 "Exit on reversal breakout (close vs M-candle extreme). When False, only stop-loss closes the trade.",
             ),
+            ParameterDef(
+                "exit_confirmation_candles",
+                "int",
+                1,
+                1,
+                10,
+                "Consecutive closed candles below the M-extreme required to confirm exit. 1 = current behaviour (single-candle exit). >1 reduces whipsaws but lags exits.",
+            ),
             ParameterDef("coste_total_bps", "float", 10.0, 0.0, 100.0, "Round-trip transaction cost in basis points"),
         ]
 
@@ -55,12 +63,38 @@ class BreakoutStrategy(Strategy):
 
         self.candles = candles
 
+    def _exit_confirmed(self, t: int, side: str, n_confirm: int) -> bool:
+        """Return True when the last `n_confirm` consecutive closed candles
+        all sit on the wrong side of their respective M-exit channel.
+
+        n_confirm=1 collapses to the original single-candle check.
+        """
+        if n_confirm <= 1:
+            # Caller will do the single-candle check directly; this is just a
+            # convenience for the multi-candle path.
+            return False
+        if t < n_confirm - 1:
+            return False
+        for k in range(n_confirm):
+            idx = t - k
+            c_close = float(self.candles.iloc[idx]["close"])
+            if side == "long":
+                ref = self.min_exit.iloc[idx]
+                if pd.isna(ref) or c_close >= float(ref):
+                    return False
+            else:  # short
+                ref = self.max_exit.iloc[idx]
+                if pd.isna(ref) or c_close <= float(ref):
+                    return False
+        return True
+
     def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
         params = self.params
         habilitar_long = bool(params.get("habilitar_long", True))
         habilitar_short = bool(params.get("habilitar_short", True))
         stop_pct = float(params.get("stop_pct", 0.02))
         salida_por_ruptura = bool(params.get("salida_por_ruptura", True))
+        n_confirm = max(1, int(params.get("exit_confirmation_candles", 1)))
 
         signals: list[Signal] = []
 
@@ -81,20 +115,30 @@ class BreakoutStrategy(Strategy):
             if low <= state.stop_price:
                 signals.append(Signal(action="stop_long", price=state.stop_price))
                 return signals
-            # Check exit on close
-            if salida_por_ruptura and close < min_exit:
-                signals.append(Signal(action="exit_long", price=close))
-                return signals
+            # Check exit on close (single or multi-candle confirmation)
+            if salida_por_ruptura:
+                if n_confirm == 1:
+                    if close < min_exit:
+                        signals.append(Signal(action="exit_long", price=close))
+                        return signals
+                elif self._exit_confirmed(t, "long", n_confirm):
+                    signals.append(Signal(action="exit_long", price=close))
+                    return signals
 
         elif state.side == "short":
             # Check stop loss (intrabar: triggered on High)
             if high >= state.stop_price:
                 signals.append(Signal(action="stop_short", price=state.stop_price))
                 return signals
-            # Check exit on close
-            if salida_por_ruptura and close > max_exit:
-                signals.append(Signal(action="exit_short", price=close))
-                return signals
+            # Check exit on close (single or multi-candle confirmation)
+            if salida_por_ruptura:
+                if n_confirm == 1:
+                    if close > max_exit:
+                        signals.append(Signal(action="exit_short", price=close))
+                        return signals
+                elif self._exit_confirmed(t, "short", n_confirm):
+                    signals.append(Signal(action="exit_short", price=close))
+                    return signals
 
         # Entry signals (only when flat)
         if state.side == "flat":

--- a/backend/strategies/breakout_trailing.py
+++ b/backend/strategies/breakout_trailing.py
@@ -1,9 +1,22 @@
 """Breakout with trailing stop.
 
 Inherits the entry/exit/initial-stop logic of BreakoutStrategy. Adds an extra
-``move_stop`` signal that trails behind price using the rolling extreme of the
-last ``trailing_lookback`` closed candles (Min for longs, Max for shorts),
-with the same ``stop_pct`` buffer that the base strategy applies at entry.
+``move_stop`` signal that trails behind price.
+
+Trailing modes:
+- ``rolling`` (default, original behaviour): trail to the rolling Min/Max of
+  the last ``trailing_lookback`` closed candles.
+- ``highwater``: track the highest high (long) / lowest low (short) since the
+  trade was opened, then trail to the lowest low (long) / highest high (short)
+  observed since that water mark. Reacts faster than rolling on strong trends
+  and stays out of older "noise" candles that pre-date the breakout.
+
+Optional refinements (all default-off so existing configs keep their numbers):
+- ``trail_buffer_pct`` lets the trailing buffer be set independently of
+  ``stop_pct`` (which sizes the initial stop). Set to 0 to keep the legacy
+  behaviour of reusing ``stop_pct`` for both.
+- ``breakeven_at_r`` moves the stop to the entry price once unrealised PnL
+  reaches N × initial-risk. Default 0 disables the rule.
 """
 
 from __future__ import annotations
@@ -17,58 +30,168 @@ from backend.strategies.breakout import BreakoutStrategy
 class BreakoutTrailingStrategy(BreakoutStrategy):
     name = "breakout_trailing"
     description = (
-        "Breakout con trailing stop. Hereda entradas/salidas de 'breakout'; "
-        "mueve el stop detrás del precio usando el Min/Max de las últimas "
-        "trailing_lookback velas cerradas (con el buffer stop_pct)."
+        "Breakout con trailing stop. Hereda entradas/salidas de 'breakout'. "
+        "Soporta trailing rolling (Min/Max de las últimas N velas, original) "
+        "o highwater (Chandelier-style desde el máximo del trade). Buffer y "
+        "stop inicial pueden separarse, y se puede activar break-even al "
+        "alcanzar N × R de profit no realizado."
     )
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Per-trade memory used to size break-even moves correctly.
+        # Resets the first time we observe a new entry_time.
+        self._initial_stop_per_entry: tuple[int, float] | None = None
 
     def get_parameters(self) -> list[ParameterDef]:
         params = super().get_parameters()
-        params.append(
-            ParameterDef(
-                "trailing_lookback",
-                "int",
-                10,
-                1,
-                500,
-                "Lookback (in closed candles) for the trailing Min/Max reference level",
-            )
+        params.extend(
+            [
+                ParameterDef(
+                    "trailing_lookback",
+                    "int",
+                    10,
+                    1,
+                    500,
+                    "Lookback (closed candles) for the trailing reference. Used by trail_mode='rolling'.",
+                ),
+                ParameterDef(
+                    "trail_mode",
+                    "str",
+                    "rolling",
+                    None,
+                    None,
+                    "Trailing reference mechanism: 'rolling' (Min/Max of last trailing_lookback velas) or 'highwater' (lows since the highest high of the trade)",
+                ),
+                ParameterDef(
+                    "trail_buffer_pct",
+                    "float",
+                    0.0,
+                    0.0,
+                    0.5,
+                    "Trailing buffer below the new low (long) / above the new high (short). 0 = reuse stop_pct (legacy behaviour).",
+                ),
+                ParameterDef(
+                    "breakeven_at_r",
+                    "float",
+                    0.0,
+                    0.0,
+                    10.0,
+                    "Move stop to entry price when unrealised PnL reaches N × initial risk. 0 disables (legacy).",
+                ),
+            ]
         )
         return params
 
     def init(self, params: dict, candles: pd.DataFrame) -> None:
         super().init(params, candles)
         lookback = int(params.get("trailing_lookback", 10))
-        # Rolling extremes over the last `lookback` closed candles (exclusive of t).
         self.trail_min = candles["low"].shift(1).rolling(lookback).min()
         self.trail_max = candles["high"].shift(1).rolling(lookback).max()
+        # Reset per-trade memory at every fresh init (one per backtest run; in
+        # live the strategy is re-instantiated per scan cycle).
+        self._initial_stop_per_entry = None
+
+    def _capture_initial_stop(self, state: PositionState) -> float:
+        """Return the initial stop for the current trade. Memoised by entry_time
+        so trailing updates don't overwrite the reference used for break-even."""
+        if state.side == "flat":
+            return 0.0
+        prev = self._initial_stop_per_entry
+        if prev is None or prev[0] != state.entry_time:
+            self._initial_stop_per_entry = (state.entry_time, state.stop_price)
+            return state.stop_price
+        return prev[1]
+
+    def _highwater_low_since_entry(self, t: int, state: PositionState) -> float:
+        """For longs: lowest low observed since the highest high of the trade."""
+        # Find entry index (open_time match); the engine guarantees it exists.
+        candles = self.candles
+        # Slice from entry candle through current candle inclusive.
+        entry_mask = candles["open_time"] == state.entry_time
+        if not entry_mask.any():
+            return float("nan")
+        entry_idx = int(candles.index[entry_mask][0])
+        if entry_idx > t:
+            return float("nan")
+        window = candles.iloc[entry_idx : t + 1]
+        hw_pos_in_window = int(window["high"].values.argmax())
+        # Lows from the high-water bar onward (inclusive of the HW bar itself).
+        lows_after_hw = window.iloc[hw_pos_in_window:]["low"]
+        return float(lows_after_hw.min())
+
+    def _highwater_high_since_entry(self, t: int, state: PositionState) -> float:
+        """For shorts: highest high observed since the lowest low of the trade."""
+        candles = self.candles
+        entry_mask = candles["open_time"] == state.entry_time
+        if not entry_mask.any():
+            return float("nan")
+        entry_idx = int(candles.index[entry_mask][0])
+        if entry_idx > t:
+            return float("nan")
+        window = candles.iloc[entry_idx : t + 1]
+        lw_pos_in_window = int(window["low"].values.argmin())
+        highs_after_lw = window.iloc[lw_pos_in_window:]["high"]
+        return float(highs_after_lw.max())
 
     def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
         signals = super().on_candle(t, candle, state)
 
         # Base class returns early on stop/exit; no trailing in that case.
-        # Only emit move_stop when a position is open and base didn't close it.
         if state.side == "flat" or any(
             s.action in ("stop_long", "stop_short", "exit_long", "exit_short") for s in signals
         ):
             return signals
 
-        stop_pct = float(self.params.get("stop_pct", 0.02))
+        params = self.params
+        stop_pct = float(params.get("stop_pct", 0.02))
+        trail_mode = str(params.get("trail_mode", "rolling")).lower()
+        trail_buffer = float(params.get("trail_buffer_pct", 0.0))
+        if trail_buffer <= 0.0:
+            trail_buffer = stop_pct  # legacy: reuse stop_pct
+        breakeven_at_r = float(params.get("breakeven_at_r", 0.0))
 
+        initial_stop = self._capture_initial_stop(state)
+
+        # Optional break-even move (applied first; trailing may still tighten further below)
+        if breakeven_at_r > 0.0 and initial_stop > 0.0 and state.entry_price > 0.0:
+            close_price = float(candle["close"])
+            if state.side == "long":
+                R = state.entry_price - initial_stop
+                if (
+                    R > 0
+                    and close_price >= state.entry_price + breakeven_at_r * R
+                    and state.entry_price > state.stop_price
+                ):
+                    signals.append(Signal(action="move_stop", stop_price=state.entry_price))
+            elif state.side == "short":
+                R = initial_stop - state.entry_price
+                if (
+                    R > 0
+                    and close_price <= state.entry_price - breakeven_at_r * R
+                    and state.entry_price < state.stop_price
+                ):
+                    signals.append(Signal(action="move_stop", stop_price=state.entry_price))
+
+        # Determine trailing reference based on mode
         if state.side == "long":
-            ref = self.trail_min.iloc[t]
+            ref = self._highwater_low_since_entry(t, state) if trail_mode == "highwater" else self.trail_min.iloc[t]
             if pd.isna(ref):
                 return signals
-            candidate = float(ref) * (1.0 - stop_pct)
-            if candidate > state.stop_price:
+            candidate = float(ref) * (1.0 - trail_buffer)
+            existing_moves = [s.stop_price for s in signals if s.action == "move_stop"]
+            current_target = max([state.stop_price] + existing_moves)
+            if candidate > current_target:
                 signals.append(Signal(action="move_stop", stop_price=candidate))
 
         elif state.side == "short":
-            ref = self.trail_max.iloc[t]
+            ref = self._highwater_high_since_entry(t, state) if trail_mode == "highwater" else self.trail_max.iloc[t]
             if pd.isna(ref):
                 return signals
-            candidate = float(ref) * (1.0 + stop_pct)
-            if candidate < state.stop_price:
+            candidate = float(ref) * (1.0 + trail_buffer)
+            existing_moves = [s.stop_price for s in signals if s.action == "move_stop"]
+            current_target = min([state.stop_price] + existing_moves)
+            if candidate < current_target:
                 signals.append(Signal(action="move_stop", stop_price=candidate))
 
         return signals

--- a/backend/strategies/support_resistance.py
+++ b/backend/strategies/support_resistance.py
@@ -34,6 +34,14 @@ class SupportResistanceStrategy(Strategy):
             ),
             ParameterDef("habilitar_long", "bool", True, None, None, "Enable long entries"),
             ParameterDef("habilitar_short", "bool", True, None, None, "Enable short entries"),
+            ParameterDef(
+                "exit_confirmation_candles",
+                "int",
+                1,
+                1,
+                10,
+                "Consecutive closed candles below the support (long) / above the resistance (short) required to confirm the exit. 1 = original single-candle exit; >1 reduces whipsaws but lags exits.",
+            ),
             ParameterDef("coste_total_bps", "float", 10.0, 0.0, 100.0, "Round-trip transaction cost in basis points"),
         ]
 
@@ -114,11 +122,31 @@ class SupportResistanceStrategy(Strategy):
         self.last_resistance = resistance
         self.candles = candles
 
+    def _exit_confirmed_sr(self, t: int, side: str, n_confirm: int) -> bool:
+        """Multi-candle confirmation: last N closed candles all on the wrong
+        side of their respective zigzag level. n_confirm <= 1 ⇒ False (caller
+        handles single-candle path)."""
+        if n_confirm <= 1 or t < n_confirm - 1:
+            return False
+        for k in range(n_confirm):
+            idx = t - k
+            c_close = float(self.candles.iloc[idx]["close"])
+            if side == "long":
+                ref = self.last_support[idx]
+                if np.isnan(ref) or c_close >= float(ref):
+                    return False
+            else:  # short
+                ref = self.last_resistance[idx]
+                if np.isnan(ref) or c_close <= float(ref):
+                    return False
+        return True
+
     def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
         params = self.params
         habilitar_long = bool(params.get("habilitar_long", True))
         habilitar_short = bool(params.get("habilitar_short", True))
         stop_pct = float(params.get("stop_pct", 0.02))
+        n_confirm = max(1, int(params.get("exit_confirmation_candles", 1)))
 
         signals: list[Signal] = []
 
@@ -138,8 +166,12 @@ class SupportResistanceStrategy(Strategy):
             if low <= state.stop_price:
                 signals.append(Signal(action="stop_long", price=state.stop_price))
                 return signals
-            # Check exit: close breaks below support
-            if close < support:
+            # Check exit: close breaks below support (single or multi-candle)
+            if n_confirm == 1:
+                if close < support:
+                    signals.append(Signal(action="exit_long", price=close))
+                    return signals
+            elif self._exit_confirmed_sr(t, "long", n_confirm):
                 signals.append(Signal(action="exit_long", price=close))
                 return signals
 
@@ -148,8 +180,12 @@ class SupportResistanceStrategy(Strategy):
             if high >= state.stop_price:
                 signals.append(Signal(action="stop_short", price=state.stop_price))
                 return signals
-            # Check exit: close breaks above resistance
-            if close > resistance:
+            # Check exit: close breaks above resistance (single or multi-candle)
+            if n_confirm == 1:
+                if close > resistance:
+                    signals.append(Signal(action="exit_short", price=close))
+                    return signals
+            elif self._exit_confirmed_sr(t, "short", n_confirm):
                 signals.append(Signal(action="exit_short", price=close))
                 return signals
 

--- a/backend/strategies/support_resistance_trailing.py
+++ b/backend/strategies/support_resistance_trailing.py
@@ -3,7 +3,14 @@
 Inherits the zigzag-based entries/exits of SupportResistanceStrategy. While a
 position is open, emits a ``move_stop`` signal whenever a newly confirmed
 support (long) or resistance (short) yields a tighter stop than the current
-one, applying the same ``stop_pct`` buffer the base strategy uses at entry.
+one.
+
+Optional refinements (default-off so existing configs preserve their numbers):
+- ``trail_buffer_pct`` lets the trailing buffer be set independently of
+  ``stop_pct`` (which sizes the initial stop). Set to 0 to keep the legacy
+  behaviour of reusing ``stop_pct`` for both.
+- ``breakeven_at_r`` moves the stop to the entry price once unrealised PnL
+  reaches N × initial-risk. Default 0 disables the rule.
 """
 
 from __future__ import annotations
@@ -11,7 +18,7 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-from backend.strategies.base import PositionState, Signal
+from backend.strategies.base import ParameterDef, PositionState, Signal
 from backend.strategies.support_resistance import SupportResistanceStrategy
 
 
@@ -20,9 +27,52 @@ class SupportResistanceTrailingStrategy(SupportResistanceStrategy):
     description = (
         "Soportes/Resistencias con trailing stop. Hereda entradas/salidas de "
         "'support_resistance'; cada vez que se confirma un nuevo soporte (long) "
-        "o resistencia (short) más cercano al precio, mueve el stop al nivel "
-        "soporte/resistencia × (1 ∓ stop_pct)."
+        "o resistencia (short) más cercano al precio, mueve el stop. Buffer "
+        "del trailing puede separarse del stop_pct inicial, y se puede activar "
+        "break-even al alcanzar N × R de profit no realizado."
     )
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Per-trade memory used to size break-even moves correctly.
+        self._initial_stop_per_entry: tuple[int, float] | None = None
+
+    def get_parameters(self) -> list[ParameterDef]:
+        params = super().get_parameters()
+        params.extend(
+            [
+                ParameterDef(
+                    "trail_buffer_pct",
+                    "float",
+                    0.0,
+                    0.0,
+                    0.5,
+                    "Trailing buffer below the new support (long) / above the new resistance (short). 0 = reuse stop_pct (legacy).",
+                ),
+                ParameterDef(
+                    "breakeven_at_r",
+                    "float",
+                    0.0,
+                    0.0,
+                    10.0,
+                    "Move stop to entry price when unrealised PnL reaches N × initial risk. 0 disables (legacy).",
+                ),
+            ]
+        )
+        return params
+
+    def init(self, params: dict, candles: pd.DataFrame) -> None:
+        super().init(params, candles)
+        self._initial_stop_per_entry = None
+
+    def _capture_initial_stop(self, state: PositionState) -> float:
+        if state.side == "flat":
+            return 0.0
+        prev = self._initial_stop_per_entry
+        if prev is None or prev[0] != state.entry_time:
+            self._initial_stop_per_entry = (state.entry_time, state.stop_price)
+            return state.stop_price
+        return prev[1]
 
     def on_candle(self, t: int, candle: pd.Series, state: PositionState) -> list[Signal]:
         signals = super().on_candle(t, candle, state)
@@ -32,18 +82,50 @@ class SupportResistanceTrailingStrategy(SupportResistanceStrategy):
         ):
             return signals
 
-        stop_pct = float(self.params.get("stop_pct", 0.02))
+        params = self.params
+        stop_pct = float(params.get("stop_pct", 0.02))
+        trail_buffer = float(params.get("trail_buffer_pct", 0.0))
+        if trail_buffer <= 0.0:
+            trail_buffer = stop_pct  # legacy
+        breakeven_at_r = float(params.get("breakeven_at_r", 0.0))
+
+        initial_stop = self._capture_initial_stop(state)
+
+        # Optional break-even move
+        if breakeven_at_r > 0.0 and initial_stop > 0.0 and state.entry_price > 0.0:
+            close_price = float(candle["close"])
+            if state.side == "long":
+                R = state.entry_price - initial_stop
+                if (
+                    R > 0
+                    and close_price >= state.entry_price + breakeven_at_r * R
+                    and state.entry_price > state.stop_price
+                ):
+                    signals.append(Signal(action="move_stop", stop_price=state.entry_price))
+            elif state.side == "short":
+                R = initial_stop - state.entry_price
+                if (
+                    R > 0
+                    and close_price <= state.entry_price - breakeven_at_r * R
+                    and state.entry_price < state.stop_price
+                ):
+                    signals.append(Signal(action="move_stop", stop_price=state.entry_price))
+
         support = self.last_support[t]
         resistance = self.last_resistance[t]
 
         if state.side == "long" and not np.isnan(support):
-            candidate = float(support) * (1.0 - stop_pct)
-            if candidate > state.stop_price:
+            candidate = float(support) * (1.0 - trail_buffer)
+            existing_moves = [s.stop_price for s in signals if s.action == "move_stop"]
+            current_target = max([state.stop_price] + existing_moves)
+            if candidate > current_target:
                 signals.append(Signal(action="move_stop", stop_price=candidate))
 
         elif state.side == "short" and not np.isnan(resistance):
-            candidate = float(resistance) * (1.0 + stop_pct)
-            if candidate < state.stop_price:
+            candidate = float(resistance) * (1.0 + trail_buffer)
+            existing_moves = [s.stop_price for s in signals if s.action == "move_stop"]
+            current_target = min([state.stop_price] + existing_moves)
+            if candidate < current_target:
                 signals.append(Signal(action="move_stop", stop_price=candidate))
 
         return signals

--- a/tests/test_breakout_strategy.py
+++ b/tests/test_breakout_strategy.py
@@ -333,6 +333,7 @@ class TestParameterDefs:
             "habilitar_long",
             "habilitar_short",
             "salida_por_ruptura",
+            "exit_confirmation_candles",
             "coste_total_bps",
         }
         assert expected == names

--- a/tests/test_support_resistance_strategy.py
+++ b/tests/test_support_resistance_strategy.py
@@ -391,6 +391,7 @@ class TestParameterDefs:
             "modo_ejecucion",
             "habilitar_long",
             "habilitar_short",
+            "exit_confirmation_candles",
             "coste_total_bps",
         }
         assert expected == names

--- a/tests/test_trailing_polish.py
+++ b/tests/test_trailing_polish.py
@@ -1,0 +1,314 @@
+"""Tests for the new optional flags added to breakout_trailing /
+support_resistance_trailing / breakout / support_resistance.
+
+Each flag defaults to a value that preserves the legacy behaviour, so the
+existing test suites continue to pass; these tests cover the *opt-in* paths.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from backend.download_engine import INTERVAL_MS
+from backend.strategies.base import PositionState
+from backend.strategies.breakout import BreakoutStrategy
+from backend.strategies.breakout_trailing import BreakoutTrailingStrategy
+from backend.strategies.support_resistance import SupportResistanceStrategy
+from backend.strategies.support_resistance_trailing import SupportResistanceTrailingStrategy
+
+
+def _df(closes, highs=None, lows=None, opens=None):
+    n = len(closes)
+    if highs is None:
+        highs = [c + 1.0 for c in closes]
+    if lows is None:
+        lows = [c - 1.0 for c in closes]
+    if opens is None:
+        opens = closes
+    step = INTERVAL_MS["1d"]
+    return pd.DataFrame(
+        {
+            "open_time": [step * i for i in range(n)],
+            "open": [float(v) for v in opens],
+            "high": [float(v) for v in highs],
+            "low": [float(v) for v in lows],
+            "close": [float(v) for v in closes],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# exit_confirmation_candles (breakout)
+# ---------------------------------------------------------------------------
+
+
+def test_breakout_exit_confirm_1_matches_legacy_single_candle_exit():
+    # 6 flat candles, then a single dip below M-min: with default n_confirm=1
+    # the trade closes immediately.
+    closes = [110.0] * 6 + [95.0]
+    lows = [109.0] * 6 + [94.0]
+    df = _df(closes, lows=lows)
+    strat = BreakoutStrategy()
+    strat.init(
+        {
+            "N_entrada": 5,
+            "M_salida": 3,
+            "stop_pct": 0.05,
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "salida_por_ruptura": True,
+            "exit_confirmation_candles": 1,
+            "modo_ejecucion": "open_next",
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    state = PositionState(side="long", entry_price=110.0, stop_price=80.0)
+    sigs = strat.on_candle(6, df.iloc[6], state)
+    assert any(s.action == "exit_long" for s in sigs)
+
+
+def test_breakout_exit_confirm_3_blocks_single_candle_dip():
+    # Same dip as above, but require 3 consecutive candles before exiting.
+    closes = [110.0] * 6 + [95.0]
+    lows = [109.0] * 6 + [94.0]
+    df = _df(closes, lows=lows)
+    strat = BreakoutStrategy()
+    strat.init(
+        {
+            "N_entrada": 5,
+            "M_salida": 3,
+            "stop_pct": 0.05,
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "salida_por_ruptura": True,
+            "exit_confirmation_candles": 3,
+            "modo_ejecucion": "open_next",
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    state = PositionState(side="long", entry_price=110.0, stop_price=80.0)
+    sigs = strat.on_candle(6, df.iloc[6], state)
+    assert all(s.action != "exit_long" for s in sigs), "single dip should not exit when 3 confirmations required"
+
+
+def test_breakout_exit_confirm_3_fires_after_three_consecutive_dips():
+    # Continuous downtrend so each candle's close is below its own M-min reference.
+    # closes 110→ trending down; lows track closes minus 1.
+    closes = [110.0, 110.0, 110.0, 110.0, 110.0, 90.0, 88.0, 85.0]
+    lows = [c - 1.0 for c in closes]
+    df = _df(closes, lows=lows)
+    strat = BreakoutStrategy()
+    strat.init(
+        {
+            "N_entrada": 5,
+            "M_salida": 3,
+            "stop_pct": 0.05,
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "salida_por_ruptura": True,
+            "exit_confirmation_candles": 3,
+            "modo_ejecucion": "open_next",
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    # min_exit at t=5: min(low[2..4])=109 → close 90<109 ✓
+    # min_exit at t=6: min(low[3..5])=89 → close 88<89 ✓
+    # min_exit at t=7: min(low[4..6])=87 → close 85<87 ✓
+    state = PositionState(side="long", entry_price=110.0, stop_price=80.0)
+    sigs = strat.on_candle(7, df.iloc[7], state)
+    assert any(s.action == "exit_long" for s in sigs)
+
+
+# ---------------------------------------------------------------------------
+# breakout_trailing: trail_buffer_pct independence + breakeven_at_r + highwater
+# ---------------------------------------------------------------------------
+
+
+def _bt_default_params(**overrides):
+    p = {
+        "N_entrada": 5,
+        "M_salida": 3,
+        "stop_pct": 0.05,
+        "trailing_lookback": 3,
+        "trail_mode": "rolling",
+        "trail_buffer_pct": 0.0,  # legacy: reuse stop_pct
+        "breakeven_at_r": 0.0,
+        "exit_confirmation_candles": 1,
+        "habilitar_long": True,
+        "habilitar_short": True,
+        "salida_por_ruptura": True,
+        "modo_ejecucion": "open_next",
+        "coste_total_bps": 0.0,
+    }
+    p.update(overrides)
+    return p
+
+
+def test_breakout_trailing_buffer_pct_overrides_stop_pct_for_trailing():
+    # Price marches up; with stop_pct=0.05 and trail_buffer_pct=0.001 the
+    # trailing stop should land much closer to the rolling-min than the legacy
+    # behaviour (which would multiply by (1 - 0.05)).
+    closes = [100.0, 102.0, 104.0, 106.0, 108.0, 110.0, 115.0]
+    highs = [c + 0.5 for c in closes]
+    lows = [c - 0.5 for c in closes]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = BreakoutTrailingStrategy()
+    strat.init(_bt_default_params(stop_pct=0.05, trail_buffer_pct=0.001), df)
+    state = PositionState(side="long", entry_price=100.0, stop_price=95.0, entry_time=int(df.iloc[0]["open_time"]))
+    sigs = strat.on_candle(6, df.iloc[6], state)
+    moves = [s for s in sigs if s.action == "move_stop"]
+    assert moves, "should emit a tightening move_stop"
+    # rolling min of last 3 lows excluding t=6: min(105.5, 107.5, 109.5) = 105.5
+    expected = 105.5 * (1 - 0.001)
+    assert abs(moves[0].stop_price - expected) < 1e-6
+
+
+def test_breakout_trailing_breakeven_moves_stop_to_entry_at_1R():
+    # Entry at 100 with initial stop at 95 → R = 5. When close ≥ 105
+    # (1R above entry) and breakeven_at_r=1 is on, stop should be moved to 100.
+    closes = [100.0, 100.5, 101.0, 102.0, 103.0, 104.0, 105.0]
+    highs = [c + 0.2 for c in closes]
+    lows = [c - 0.2 for c in closes]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = BreakoutTrailingStrategy()
+    strat.init(
+        _bt_default_params(stop_pct=0.05, breakeven_at_r=1.0, trailing_lookback=3),
+        df,
+    )
+    state = PositionState(side="long", entry_price=100.0, stop_price=95.0, entry_time=int(df.iloc[0]["open_time"]))
+    # Iterate so the strategy captures the initial stop on first observation
+    for t in range(7):
+        sigs = strat.on_candle(t, df.iloc[t], state)
+        be = [s for s in sigs if s.action == "move_stop" and abs(s.stop_price - 100.0) < 1e-6]
+        if be:
+            return
+    raise AssertionError("expected a break-even move_stop at 100.0 once close hit 105")
+
+
+def test_breakout_trailing_highwater_uses_lows_only_after_high_water():
+    # Build: low=98 in the middle (BEFORE the high water), then a new high at the end.
+    # In rolling mode with lookback=3 the trailing reference would be low=98
+    # when the rolling window includes the dip. In highwater mode it should
+    # be the LATEST low (after the high water), not 98.
+    closes = [100.0, 98.0, 100.0, 105.0, 108.0, 112.0]
+    highs = [101.0, 99.0, 101.0, 106.0, 109.0, 113.0]
+    lows = [99.0, 97.0, 99.0, 104.0, 107.0, 111.0]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = BreakoutTrailingStrategy()
+    strat.init(_bt_default_params(stop_pct=0.001, trail_mode="highwater", trail_buffer_pct=0.001), df)
+    state = PositionState(side="long", entry_price=100.0, stop_price=95.0, entry_time=int(df.iloc[0]["open_time"]))
+    # At t=5: highest high in [0..5] is 113 at index 5.
+    # Lows since hw_idx=5 are just [111]. Stop candidate ≈ 111 * (1 - 0.001).
+    sigs = strat.on_candle(5, df.iloc[5], state)
+    moves = [s for s in sigs if s.action == "move_stop"]
+    assert moves, "should emit move_stop in highwater mode after a fresh high"
+    expected = 111.0 * (1 - 0.001)
+    assert abs(moves[0].stop_price - expected) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# support_resistance_trailing: trail_buffer_pct + breakeven
+# ---------------------------------------------------------------------------
+
+
+def test_sr_trailing_buffer_pct_overrides_stop_pct_for_trailing():
+    # Build pivots and confirm the trailing buffer is applied independently.
+    closes = [100, 105, 110, 105, 100, 95, 96, 100, 105, 112]
+    highs = [c + 0.5 for c in closes]
+    lows = [c - 0.5 for c in closes]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = SupportResistanceTrailingStrategy()
+    strat.init(
+        {
+            "reversal_pct": 0.02,
+            "stop_pct": 0.05,
+            "trail_buffer_pct": 0.001,
+            "breakeven_at_r": 0.0,
+            "exit_confirmation_candles": 1,
+            "modo_ejecucion": "open_next",
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    # Pretend long opened at 100 with a stop well below the latest support.
+    state = PositionState(side="long", entry_price=100.0, stop_price=80.0, entry_time=int(df.iloc[0]["open_time"]))
+    # Iterate so the latest support has been confirmed.
+    last_move = None
+    for t in range(len(df)):
+        sigs = strat.on_candle(t, df.iloc[t], state)
+        for s in sigs:
+            if s.action == "move_stop":
+                last_move = s
+    assert last_move is not None
+    # When buffer is 0.1% rather than 5%, the stop should be much closer to
+    # the support level (NOT support * 0.95).
+    # Roughly: support * (1 - 0.001) — exact value depends on the confirmed pivot
+    assert last_move.stop_price > 80.0, "stop should have tightened"
+
+
+def test_sr_trailing_breakeven_at_1R():
+    closes = [100, 102, 105, 108, 110, 112, 115]
+    highs = [c + 0.2 for c in closes]
+    lows = [c - 0.2 for c in closes]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = SupportResistanceTrailingStrategy()
+    strat.init(
+        {
+            "reversal_pct": 0.02,
+            "stop_pct": 0.05,
+            "trail_buffer_pct": 0.0,
+            "breakeven_at_r": 1.0,
+            "exit_confirmation_candles": 1,
+            "modo_ejecucion": "open_next",
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    # entry=100, initial stop=95 ⇒ R=5; close≥105 should trigger move to 100
+    state = PositionState(side="long", entry_price=100.0, stop_price=95.0, entry_time=int(df.iloc[0]["open_time"]))
+    for t in range(len(df)):
+        sigs = strat.on_candle(t, df.iloc[t], state)
+        be = [s for s in sigs if s.action == "move_stop" and abs(s.stop_price - 100.0) < 1e-6]
+        if be:
+            return
+    raise AssertionError("expected break-even move_stop at 100.0 once close hit 105")
+
+
+# ---------------------------------------------------------------------------
+# support_resistance: exit_confirmation_candles
+# ---------------------------------------------------------------------------
+
+
+def test_sr_exit_confirm_3_requires_three_consecutive_dips():
+    # Build pivots so a support is confirmed, then check that a single close
+    # below support doesn't exit when 3 confirmations are required.
+    closes = [100, 105, 110, 105, 100, 95, 96, 100, 105, 99]  # last dip below support
+    highs = [c + 0.5 for c in closes]
+    lows = [c - 0.5 for c in closes]
+    df = _df(closes, highs=highs, lows=lows)
+    strat = SupportResistanceStrategy()
+    strat.init(
+        {
+            "reversal_pct": 0.02,
+            "stop_pct": 0.05,
+            "exit_confirmation_candles": 3,
+            "modo_ejecucion": "open_next",
+            "habilitar_long": True,
+            "habilitar_short": True,
+            "coste_total_bps": 0.0,
+        },
+        df,
+    )
+    state = PositionState(side="long", entry_price=110.0, stop_price=80.0, entry_time=int(df.iloc[2]["open_time"]))
+    sigs = strat.on_candle(len(df) - 1, df.iloc[-1], state)
+    assert all(s.action != "exit_long" for s in sigs), (
+        "single dip below support should not trigger exit when 3-candle confirmation required"
+    )


### PR DESCRIPTION
Closes part of the polish work raised in #132 follow-up — adds optional refinements to the existing trailing strategies that target the user's described workflow (catch breakouts, trail stop pinned to new lows since the high, % buffer to survive spikes, configurable per-trade behaviour).

## What's added (all default-off ⇒ no breaking change)

### `breakout_trailing`
- **`trail_mode`** — `'rolling'` (default, original) or `'highwater'` (Chandelier-style: lowest low since the highest high of the trade). Reacts faster on strong trends.
- **`trail_buffer_pct`** — independent trailing buffer; 0 reuses `stop_pct` (legacy).
- **`breakeven_at_r`** — move stop to entry once profit ≥ N × initial risk. 0 disables.

### `support_resistance_trailing`
- **`trail_buffer_pct`** + **`breakeven_at_r`** — same semantics. (No `trail_mode` — trail is anchored to confirmed zigzag pivots.)

### `breakout` and `support_resistance` (base classes)
- **`exit_confirmation_candles`** — require N consecutive closed candles on the wrong side of the M-extreme/pivot before firing exit. 1 = legacy. >1 reduces whipsaws. Inherited by the trailing variants.

## BTC × 5-TF impact (legacy → all flags ON)

`breakout_trailing`:

| TF | composite legacy | composite polished | profit | DD |
|---|---:|---:|---:|---:|
| 1h | -161 | -167 | -78% → -81% | -83% → -85% |
| 4h | -23 | -38 | +33% → +4% | -56% → -41% |
| 1d | **-94** | **+30** | -31% → +72% | -64% → -42% |
| 1w | **-97** | **+799** | -4% → +831% | -93% → -31% |
| 1M | **-137** | **-23** | -48% → +36% | -88% → -59% |

`support_resistance_trailing`:

| TF | composite legacy | composite polished | notes |
|---|---:|---:|---|
| 1h | -139 | -135 | (confirm=2 only: -94) |
| 4h | -144 | -168 | small loss with buffer; better with confirm only |
| 1d | -136 | -130 | (buffer 0.5%) |
| 1w | **+5682** | **+6029** | already-best cell; further tightening |
| 1M | +436 | +436 | unchanged |

The single biggest lever:
- For `breakout_trailing`: **`trail_mode='highwater'`** (turns a losing weekly into +700+ composite).
- For `support_resistance_trailing`: **`exit_confirmation_candles=2`** on intraday cells.

## Tests

- 9 new unit tests in `tests/test_trailing_polish.py` covering each flag (legacy + opt-in path).
- 8/8 parity cases on slot_a × {close_current, open_next} pass — defaults preserve trade-log equivalence with live.
- Full suite: **300 passed**, 0 failed.

## Out of scope

- The `highwater` helper does an O(N_since_entry) scan per candle when active. Fine in practice (typical trades span <1k candles); add caching later if profiling shows it.
- Live mode for the new flags works on intraday TFs. 1w/1M still need #134 (the `ensure_candles` alignment fix) before live can pick them up.

## Test plan

- [x] `pytest -q` — 300 passed.
- [x] `pytest -m slow tests/integration/test_parity.py -k 'breakout or support_resistance'` (slot_a) — 8 passed.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] `npm run lint` — clean.
- [x] Manual sanity: each strategy still loads via `/api/strategies` with correct param schema for frontend auto-render.

Refs: #132
🤖 Generated with [Claude Code](https://claude.com/claude-code)