### PR TITLE
fix(download): align 1w/1M expected_open_times with Binance candles (#134)

### DIFF
--- a/backend/download_engine.py
+++ b/backend/download_engine.py
@@ -40,17 +40,28 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+# Epoch (1970-01-01) was a Thursday; the first Monday after epoch is 1970-01-05.
+# Used to align 1w boundaries with Binance's Monday 00:00 UTC weekly candles.
+_MONDAY_EPOCH_OFFSET_MS = 4 * 86_400_000
+
+
 def _expected_open_times(start_ms: int, end_ms: int, interval: str) -> list[int]:
     """
     Generate the list of expected candle open_time values for a given range.
-    For 1M intervals, we approximate at 30 days.
+
+    Binance aligns 1w candles to Monday 00:00 UTC and 1M candles to the
+    calendar 1st 00:00 UTC; both deviate from a naive epoch-modulo step,
+    so they need bespoke alignment instead of `(start_ms // step) * step`.
     """
+    if interval == "1M":
+        return _expected_open_times_monthly(start_ms, end_ms)
+
     step = INTERVAL_MS.get(interval)
     if step is None:
         raise ValueError(f"Unknown interval: {interval}")
 
-    # Align start to interval boundary
-    aligned_start = (start_ms // step) * step
+    offset = _MONDAY_EPOCH_OFFSET_MS if interval == "1w" else 0
+    aligned_start = ((start_ms - offset) // step) * step + offset
     if aligned_start < start_ms:
         aligned_start += step
 
@@ -60,6 +71,27 @@ def _expected_open_times(start_ms: int, end_ms: int, interval: str) -> list[int]
         times.append(t)
         t += step
     return times
+
+
+def _expected_open_times_monthly(start_ms: int, end_ms: int) -> list[int]:
+    """Enumerate calendar-month open_time values (1st of each month, 00:00 UTC) in [start_ms, end_ms)."""
+    start_dt = datetime.fromtimestamp(start_ms / 1000, tz=UTC)
+    aligned = datetime(start_dt.year, start_dt.month, 1, tzinfo=UTC)
+    if int(aligned.timestamp() * 1000) < start_ms:
+        aligned = _next_month(aligned)
+
+    times: list[int] = []
+    t = aligned
+    while int(t.timestamp() * 1000) < end_ms:
+        times.append(int(t.timestamp() * 1000))
+        t = _next_month(t)
+    return times
+
+
+def _next_month(dt: datetime) -> datetime:
+    if dt.month == 12:
+        return dt.replace(year=dt.year + 1, month=1)
+    return dt.replace(month=dt.month + 1)
 
 
 async def _get_existing_open_times(
@@ -351,12 +383,19 @@ async def ensure_candles(symbol: str, interval: str, start_ms: int, end_ms: int)
     if key in _syncing:
         return False
 
-    # Check whether the last required candle (end_ms - step) is present
-    step_ms = INTERVAL_MS.get(interval)
-    if step_ms is None:
+    if interval not in INTERVAL_MS:
         raise ValueError(f"Unknown interval: {interval}")
 
-    last_required = end_ms - step_ms  # open_time of the last candle we need
+    # Derive the last expected candle from the alignment-aware generator —
+    # `end_ms - step_ms` only matches when end_ms sits exactly on a Binance
+    # boundary, which fails for 1w (Monday) and 1M (calendar) intervals.
+    expected_times = _expected_open_times(start_ms, end_ms, interval)
+    expected_count = len(expected_times)
+    if expected_count == 0:
+        _verified_ranges[key] = end_ms
+        return True
+
+    last_required = expected_times[-1]
 
     async with get_db() as db:
         cursor = await db.execute(
@@ -366,14 +405,11 @@ async def ensure_candles(symbol: str, interval: str, start_ms: int, end_ms: int)
         row = await cursor.fetchone()
         actual_count = row[0] if row else 0
 
-        # Also check the critical last candle is there
         cursor2 = await db.execute(
             "SELECT 1 FROM klines WHERE symbol=? AND interval=? AND open_time=?",
             (symbol, interval, last_required),
         )
         has_last = await cursor2.fetchone() is not None
-
-    expected_count = len(_expected_open_times(start_ms, end_ms, interval))
 
     if has_last and actual_count >= expected_count:
         # All candles present — update cache

--- a/tests/test_download_engine.py
+++ b/tests/test_download_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from datetime import UTC, datetime
 
 import aiosqlite
 import pytest
@@ -16,6 +17,11 @@ from backend.download_engine import (
     _get_existing_open_times,
     _upsert_candles,
 )
+
+
+def _ms(year: int, month: int, day: int) -> int:
+    return int(datetime(year, month, day, tzinfo=UTC).timestamp() * 1000)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -111,6 +117,58 @@ class TestExpectedOpenTimes:
     def test_unknown_interval_raises(self):
         with pytest.raises(ValueError, match="Unknown interval"):
             _expected_open_times(0, 1_000_000, "99x")
+
+    def test_1w_monday_alignment(self):
+        # Range starts mid-week (Wed 2024-01-03) — first expected candle should
+        # be Mon 2024-01-08, not the Thursday-anchored snap of the old code.
+        start = _ms(2024, 1, 3)
+        end = _ms(2024, 2, 6)
+        times = _expected_open_times(start, end, "1w")
+        assert times == [
+            _ms(2024, 1, 8),
+            _ms(2024, 1, 15),
+            _ms(2024, 1, 22),
+            _ms(2024, 1, 29),
+            _ms(2024, 2, 5),
+        ]
+        for ts in times:
+            assert datetime.fromtimestamp(ts / 1000, tz=UTC).strftime("%A") == "Monday"
+
+    def test_1w_start_on_monday(self):
+        start = _ms(2024, 1, 1)  # Monday
+        end = _ms(2024, 1, 22)
+        times = _expected_open_times(start, end, "1w")
+        assert times == [_ms(2024, 1, 1), _ms(2024, 1, 8), _ms(2024, 1, 15)]
+
+    def test_1M_calendar_months(self):
+        # Mid-month start should snap up to the 1st of next month, then enumerate
+        # by calendar month (28/29/30/31 days), not 30-day fixed steps.
+        start = _ms(2024, 1, 15)
+        end = _ms(2024, 6, 1)
+        times = _expected_open_times(start, end, "1M")
+        assert times == [
+            _ms(2024, 2, 1),
+            _ms(2024, 3, 1),
+            _ms(2024, 4, 1),
+            _ms(2024, 5, 1),
+        ]
+
+    def test_1M_aligned_start_includes_first(self):
+        start = _ms(2024, 1, 1)
+        end = _ms(2024, 4, 1)
+        times = _expected_open_times(start, end, "1M")
+        assert times == [_ms(2024, 1, 1), _ms(2024, 2, 1), _ms(2024, 3, 1)]
+
+    def test_1M_year_boundary(self):
+        start = _ms(2023, 11, 1)
+        end = _ms(2024, 3, 1)
+        times = _expected_open_times(start, end, "1M")
+        assert times == [
+            _ms(2023, 11, 1),
+            _ms(2023, 12, 1),
+            _ms(2024, 1, 1),
+            _ms(2024, 2, 1),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ensure_candles.py
+++ b/tests/test_ensure_candles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 from backend.database import get_db, init_db
 from backend.download_engine import (
     INTERVAL_MS,
+    _expected_open_times,
     _syncing,
     _verified_ranges,
     ensure_candles,
@@ -141,6 +143,38 @@ class TestEnsureCandlesDataPresent:
 
         assert result is False
         mock_task.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests: alignment regression for 1w / 1M (issue #134)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureCandlesAlignment:
+    @pytest.mark.asyncio
+    async def test_1w_returns_true_with_monday_aligned_data(self):
+        """Regression for #134: end_ms not on a Monday boundary should still
+        recognise a fully-populated DB without relaunching syncs forever."""
+        await init_db()
+        start_ms = int(datetime(2024, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        end_ms = int(datetime(2024, 2, 18, tzinfo=UTC).timestamp() * 1000)  # a Sunday
+
+        await _insert_candles("BTCUSDT", "1w", _expected_open_times(start_ms, end_ms, "1w"))
+
+        result = await ensure_candles("BTCUSDT", "1w", start_ms, end_ms)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_1M_returns_true_with_calendar_aligned_data(self):
+        """Regression for #134: 1M candles align to the calendar 1st, not 30-day chunks."""
+        await init_db()
+        start_ms = int(datetime(2023, 1, 1, tzinfo=UTC).timestamp() * 1000)
+        end_ms = int(datetime(2024, 1, 15, tzinfo=UTC).timestamp() * 1000)
+
+        await _insert_candles("BTCUSDT", "1M", _expected_open_times(start_ms, end_ms, "1M"))
+
+        result = await ensure_candles("BTCUSDT", "1M", start_ms, end_ms)
+        assert result is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_expected_open_times` now produces Monday-aligned 1w timestamps and calendar-month 1M timestamps, matching what Binance actually returns.
- `ensure_candles` derives the last-required candle from the alignment-aware generator instead of `end_ms - step_ms`, so a fully-synced DB is recognised on every call instead of relaunching syncs forever.
- Adds 5 unit tests for `_expected_open_times` (1w mid-week / on-Monday, 1M mid-month / aligned-start / year boundary) and 2 regression tests for `ensure_candles` covering 1w + 1M.

Closes #134.

## Test plan

- [x] `pytest -q` — 320 passed
- [x] `ruff check backend/ tests/` — clean
- [x] `ruff format --check backend/ tests/` — clean
- [ ] After merge: spin up a 1w `signal_config` in dev and confirm `ensure_candles: launched async sync` no longer repeats once the sync finishes (logs should show `sync complete for ... 1w` followed by no more launches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)