### PR TITLE
fix(risk): reject max_loss_pct=0 + clarify dual-role UX (#147 #148 #149)

### DIFF
--- a/backend/api/signal_routes.py
+++ b/backend/api/signal_routes.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from backend.auth import AuthUser, get_current_user
 from backend.database import get_db
@@ -38,7 +38,11 @@ class SignalConfigCreate(BaseModel):
     polling_interval_s: int | None = None
     telegram_enabled: bool = False
     max_loss_per_trade_enabled: bool = False
-    max_loss_per_trade_pct: float = 0.02
+    # gt=0 in both modes: in `full_equity` the field is the skip-filter
+    # threshold (a 0 threshold would drop every entry); in `risk_based` it is
+    # the sizing target (a 0 target produces invested=0 no-op trades — see
+    # #147). The single guard rejects both nonsensical configurations.
+    max_loss_per_trade_pct: float = Field(0.02, gt=0)
     position_sizing_mode: Literal["full_equity", "risk_based"] = "full_equity"
 
 
@@ -52,7 +56,7 @@ class SignalConfigPatch(BaseModel):
     polling_interval_s: int | None = None
     telegram_enabled: bool | None = None
     max_loss_per_trade_enabled: bool | None = None
-    max_loss_per_trade_pct: float | None = None
+    max_loss_per_trade_pct: float | None = Field(None, gt=0)
     position_sizing_mode: Literal["full_equity", "risk_based"] | None = None
 
 

--- a/backend/risk.py
+++ b/backend/risk.py
@@ -51,6 +51,12 @@ def compute_risk_based_size(
         raise ValueError(f"entry_price must be > 0, got {entry_price}")
     if current_portfolio <= 0:
         raise ValueError(f"current_portfolio must be > 0, got {current_portfolio}")
+    if max_loss_pct <= 0:
+        # max_loss_pct=0 would silently produce invested=0/qty=0 (no-op trade
+        # that occupies the active slot). Reject so the caller — and ultimately
+        # the pydantic Field(gt=0) on signal_configs.max_loss_per_trade_pct —
+        # surface the misuse instead of opening a degenerate position.
+        raise ValueError(f"max_loss_pct must be > 0 in risk_based sizing, got {max_loss_pct}")
     distance = abs(entry_price - stop_base)
     if distance <= 0:
         raise ValueError(f"distance entry_price-stop_base must be > 0, got entry={entry_price} stop={stop_base}")

--- a/frontend/src/components/signals/CapitalConfig.jsx
+++ b/frontend/src/components/signals/CapitalConfig.jsx
@@ -6,7 +6,14 @@ const TIPS = {
   invested: 'Capital efectivo a desplegar por trade en USD. Se traduce internamente a leverage = invested/portfolio.',
 }
 
-export function CapitalConfig({ portfolio, setPortfolio, leverage, setLeverage, investedAmount, setInvestedAmount, mode, setMode, disabled }) {
+export function CapitalConfig({ portfolio, setPortfolio, leverage, setLeverage, investedAmount, setInvestedAmount, mode, setMode, disabled, lockMode = null }) {
+  // ``lockMode`` (#149): when set, the toggle whose value differs from
+  // ``lockMode`` is disabled. Caller is responsible for forcing ``mode`` to
+  // ``lockMode`` when entering the locked state — the component does not
+  // self-correct to keep the side-effect surface minimal.
+  const leverageLocked = lockMode !== null && lockMode !== 'leverage'
+  const investedLocked = lockMode !== null && lockMode !== 'invested'
+  const lockTooltip = 'En risk-based el invested_amount se ignora — sizing derivado del stop distance.'
   return (
     <div>
       <div style={{ display: 'flex', gap: 'var(--space-2)', marginBottom: 'var(--space-3)' }}>
@@ -14,13 +21,15 @@ export function CapitalConfig({ portfolio, setPortfolio, leverage, setLeverage, 
           type="button"
           className={`btn btn-sm ${mode === 'leverage' ? 'btn-primary' : 'btn-secondary'}`}
           onClick={() => setMode('leverage')}
-          disabled={disabled}
+          disabled={disabled || leverageLocked}
+          title={leverageLocked ? lockTooltip : undefined}
         >Portfolio + Leverage</button>
         <button
           type="button"
           className={`btn btn-sm ${mode === 'invested' ? 'btn-primary' : 'btn-secondary'}`}
           onClick={() => setMode('invested')}
-          disabled={disabled}
+          disabled={disabled || investedLocked}
+          title={investedLocked ? lockTooltip : undefined}
         >Portfolio + Invested</button>
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-3)' }}>

--- a/frontend/src/components/signals/ConfigForm.jsx
+++ b/frontend/src/components/signals/ConfigForm.jsx
@@ -23,7 +23,7 @@ const FIELD_TIPS = {
   costBps: 'Coste de transacción aplicado a cada lado del trade en basis points (1 bps = 0.01%). Binance ≈ 10 bps/lado.',
   maintenanceMargin: 'Margen de mantenimiento usado para calcular el precio de liquidación. Binance baseline ≈ 0.005 (0.5%) para notional bajo.',
   maxLossEnabled: 'Si está activo, descarta entradas cuya pérdida estimada (entry → stop, considerando el apalancamiento) supere el % de equity configurado.',
-  maxLossPct: 'Pérdida máxima permitida por trade como fracción del equity. E.g. 0.02 = "no abrir si la pérdida si salta el stop sería >2% del capital actual". Con leverage>1 escala automáticamente.',
+  maxLossPct: 'Doble rol según Position sizing: en full_equity es el umbral del skip filter (entradas con pérdida-si-stop > X% se descartan; sólo aplica si Max loss/trade está On). En risk_based es el target de pérdida-si-stop (la entrada se dimensiona para que la pérdida realizada iguale X%, capada por el leverage).',
   positionSizingMode: 'full_equity (legacy): cada entrada despliega current_portfolio × leverage. risk_based: la entrada se dimensiona para que, si salta el stop, la pérdida realizada iguale Max loss % (capada por el límite de leverage). En risk_based el campo Invested amount (capital fijo) se ignora.',
 }
 
@@ -96,11 +96,17 @@ export function ConfigForm({ strategies, onCreated }) {
   const visibleParams = (currentStrat?.parameters ?? []).filter(p => p.name !== 'coste_total_bps')
 
   const step1Valid = !!selectedStrat
+  // ``maxLossPct > 0`` is required whenever the value is actually applied:
+  // either when the skip filter is on (#142) or when sizing is risk-based
+  // (#144 → #147 — pct=0 would produce no-op trades). Pydantic enforces gt=0
+  // backend-side; this gate is just for UX so "Next →" disables before the
+  // 422 round-trip.
+  const maxLossActive = maxLossEnabled || positionSizingMode === 'risk_based'
   const step2Valid =
     portfolio > 0 &&
     maintenanceMarginPct >= 0 &&
     costBps >= 0 &&
-    (!maxLossEnabled || maxLossPct > 0) &&
+    (!maxLossActive || maxLossPct > 0) &&
     (capitalMode === 'leverage' ? leverage > 0 : investedAmount > 0)
 
   const summary = useMemo(() => ({
@@ -117,7 +123,11 @@ export function ConfigForm({ strategies, onCreated }) {
       ? `risk-based (target ${(maxLossPct * 100).toFixed(2)}% por trade)`
       : 'full equity',
     Portfolio: fmtMoney(portfolio),
-    ...(capitalMode === 'leverage'
+    // In risk_based the invested_amount is overridden by the sizing helper, so
+    // hide the "Invested amount" line even if the user managed to land on
+    // capitalMode='invested' (the auto-switch normally forces leverage when
+    // entering risk_based, but a stale state path could still get there).
+    ...(positionSizingMode === 'risk_based' || capitalMode === 'leverage'
       ? { Leverage: leverage > 1 ? `${leverage}× (liquidación calculada)` : `${leverage}× (sin apalancamiento)` }
       : { 'Invested amount': fmtMoney(investedAmount) }),
   }), [symbol, interval, selectedStrat, paramValues, costBps, maintenanceMarginPct, maxLossEnabled, maxLossPct, positionSizingMode, portfolio, leverage, investedAmount, capitalMode])
@@ -267,15 +277,32 @@ export function ConfigForm({ strategies, onCreated }) {
                 </div>
               </div>
               <div className="form-group">
-                <FieldLabel tooltip={FIELD_TIPS.maxLossPct}>Max loss % (equity)</FieldLabel>
+                <FieldLabel tooltip={FIELD_TIPS.maxLossPct}>
+                  {positionSizingMode === 'risk_based' ? 'Max loss % (target)' : 'Max loss % (skip threshold)'}
+                </FieldLabel>
                 <input type="number" className="form-control" value={maxLossPct} min={0} step={0.001}
                   onChange={e => setMaxLossPct(parseFloat(e.target.value) || 0)}
                   disabled={loading || (!maxLossEnabled && positionSizingMode !== 'risk_based')} />
+                {positionSizingMode !== 'risk_based' && !maxLossEnabled && (
+                  <div style={{ marginTop: '4px', fontSize: '0.72rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                    (sin uso — activa Max loss/trade para aplicar el skip filter)
+                  </div>
+                )}
               </div>
               <div className="form-group" style={{ gridColumn: '1 / span 2' }}>
                 <FieldLabel tooltip={FIELD_TIPS.positionSizingMode}>Position sizing</FieldLabel>
                 <select className="form-control" value={positionSizingMode}
-                  onChange={e => setPositionSizingMode(e.target.value)} disabled={loading}>
+                  onChange={e => {
+                    const next = e.target.value
+                    setPositionSizingMode(next)
+                    // Auto-switch to leverage when entering risk_based (#149):
+                    // invested_amount is overridden in this mode, so the toggle
+                    // is locked to "Portfolio + Leverage". investedAmount state
+                    // is preserved for when the user switches back.
+                    if (next === 'risk_based' && capitalMode === 'invested') {
+                      setCapitalMode('leverage')
+                    }
+                  }} disabled={loading}>
                   <option value="full_equity">Full equity (legacy)</option>
                   <option value="risk_based">Risk-based (target Max loss %)</option>
                 </select>
@@ -297,6 +324,7 @@ export function ConfigForm({ strategies, onCreated }) {
               investedAmount={investedAmount} setInvestedAmount={setInvestedAmount}
               mode={capitalMode} setMode={setCapitalMode}
               disabled={loading}
+              lockMode={positionSizingMode === 'risk_based' ? 'leverage' : null}
             />
           </div>
         </div>

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -353,3 +353,27 @@ class TestRiskBasedSizeDegenerate:
                 max_loss_pct=0.01,
                 leverage=1.0,
             )
+
+    def test_zero_max_loss_pct_raises(self):
+        # max_loss_pct=0 would silently produce invested=0 / quantity=0 (no-op
+        # trade that still occupies the active slot). Must raise — see #147.
+        with pytest.raises(ValueError):
+            compute_risk_based_size(
+                side="long",
+                entry_price=100.0,
+                stop_base=99.0,
+                current_portfolio=10_000.0,
+                max_loss_pct=0.0,
+                leverage=1.0,
+            )
+
+    def test_negative_max_loss_pct_raises(self):
+        with pytest.raises(ValueError):
+            compute_risk_based_size(
+                side="long",
+                entry_price=100.0,
+                stop_base=99.0,
+                current_portfolio=10_000.0,
+                max_loss_pct=-0.01,
+                leverage=1.0,
+            )

--- a/tests/test_signal_config_position_sizing_api.py
+++ b/tests/test_signal_config_position_sizing_api.py
@@ -177,3 +177,57 @@ def test_patch_unrelated_field_preserves_mode():
     config = _fetch_config(client, config_id)
     assert config["active"] is False
     assert config["position_sizing_mode"] == "risk_based"
+
+
+# ---------------------------------------------------------------------------
+# #147: max_loss_per_trade_pct must be > 0 in both modes
+# ---------------------------------------------------------------------------
+
+
+def test_create_rejects_zero_max_loss_pct_in_risk_based():
+    """In risk_based mode, pct=0 would produce no-op trades — pydantic must reject."""
+    user = asyncio.run(_init_schema_and_user())
+    client = TestClient(_build_app(user))
+
+    resp = client.post(
+        "/api/signals/configs",
+        json=_base_payload(position_sizing_mode="risk_based", max_loss_per_trade_pct=0),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_create_rejects_zero_max_loss_pct_in_full_equity():
+    """A 0 skip threshold also makes no sense — pydantic enforces gt=0 across both modes."""
+    user = asyncio.run(_init_schema_and_user())
+    client = TestClient(_build_app(user))
+
+    resp = client.post(
+        "/api/signals/configs",
+        json=_base_payload(max_loss_per_trade_pct=0),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_create_rejects_negative_max_loss_pct():
+    user = asyncio.run(_init_schema_and_user())
+    client = TestClient(_build_app(user))
+
+    resp = client.post(
+        "/api/signals/configs",
+        json=_base_payload(max_loss_per_trade_pct=-0.01),
+    )
+    assert resp.status_code == 422, resp.text
+
+
+def test_patch_rejects_zero_max_loss_pct():
+    user = asyncio.run(_init_schema_and_user())
+    client = TestClient(_build_app(user))
+
+    create = client.post("/api/signals/configs", json=_base_payload())
+    config_id = create.json()["id"]
+
+    resp = client.patch(
+        f"/api/signals/configs/{config_id}",
+        json={"max_loss_per_trade_pct": 0},
+    )
+    assert resp.status_code == 422, resp.text


### PR DESCRIPTION
## Summary

Three follow-ups to #144 (risk-based position sizing) bundled in one PR — they share the same wizard surface (`ConfigForm.jsx`) and form a coherent UX/validation sweep.

- **#147 (bug)** — `max_loss_per_trade_pct=0` in `risk_based` produced silent no-op trades. Defence in depth: pydantic `Field(gt=0)` on POST + PATCH, `ValueError` in `compute_risk_based_size`, and `step2Valid` UX gate so the wizard's "Next →" disables before the API rejects.
- **#148 (UX)** — `Max loss %` field plays two different roles by mode (skip threshold in `full_equity`, sizing target in `risk_based`). Now the label flips dynamically, the tooltip spells out the dual role, and an italic "(sin uso — activa Max loss/trade...)" annotation appears when the value is inert.
- **#149 (UX)** — "Portfolio + Invested" toggle was selectable under `risk_based` even though `invested_amount` is overridden there. Now it's disabled with a tooltip; switching to `risk_based` from `invested` mode auto-switches the capital toggle to `leverage` (preserving `investedAmount` state); Step 3 summary hides the "Invested amount" line defensively.

Closes #147, #148, #149.

## Test plan

- [x] `pytest -q` — 377 non-slow tests pass (371 baseline + 6 new for #147: 2 unit on the helper, 4 API 422 round-trips).
- [x] `ruff check backend/ tests/` and `ruff format --check` — clean.
- [x] `npm run lint` and `npm run build` — clean.
- [x] **Browser smoke** (playwright-cli + local stack, `AUTH_ENABLED=false`):
  - **#148**: in `full_equity` with toggle off, label reads "Max loss % (skip threshold)" with the inert annotation; switching to `risk_based` flips to "Max loss % (target)" and removes the annotation.
  - **#149**: starting on "Portfolio + Invested", switching to `risk_based` auto-switches the capital toggle to "Portfolio + Leverage"; "Portfolio + Invested" button becomes `[disabled]` with the explanatory tooltip.
  - **#147**: setting `Max loss % = 0` in `risk_based` disables the "Next →" button; direct API POST with `max_loss_per_trade_pct=0` returns 422 (`type: greater_than`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)